### PR TITLE
doozer: Use Doozer's built-in jobserver for make.

### DIFF
--- a/.doozer.json
+++ b/.doozer.json
@@ -3,72 +3,72 @@
     "jessie-i386": {
       "buildenv": "jessie-i386",
       "builddeps": ["build-essential"],
-      "buildcmd": "make -j ${PARALLEL}"
+      "buildcmd": "make -j"
     },
     "trusty-i386": {
       "buildenv": "trusty-i386",
       "builddeps": ["build-essential"],
-      "buildcmd": "make -j ${PARALLEL}"
+      "buildcmd": "make -j"
     },
     "trusty-amd64": {
       "buildenv": "trusty-amd64",
       "builddeps": ["build-essential"],
-      "buildcmd": "make -j ${PARALLEL}"
+      "buildcmd": "make -j"
     },
     "xenial-i386": {
       "buildenv": "xenial-i386",
       "builddeps": ["build-essential"],
-      "buildcmd": "make -j ${PARALLEL}"
+      "buildcmd": "make -j"
     },
     "xenial-amd64": {
       "buildenv": "xenial-amd64",
       "builddeps": ["build-essential"],
-      "buildcmd": "make -j ${PARALLEL}"
+      "buildcmd": "make -j"
     },
     "xenial-armhf": {
       "buildenv": "xenial-armhf",
       "builddeps": ["build-essential"],
-      "buildcmd": "make -j ${PARALLEL}"
+      "buildcmd": "make -j"
     },
     "xenial-arm64": {
       "buildenv": "xenial-arm64",
       "builddeps": ["build-essential"],
-      "buildcmd": "make -j ${PARALLEL}"
+      "buildcmd": "make -j"
     },
     "fedora24-x86_64-g++": {
       "buildenv": "fedora24-x86_64",
       "builddeps": ["cmake", "make", "clang"],
-      "buildcmd": ["mkdir build", "cd build", "CXX=g++ cmake ..", "cmake --build .", "ctest --output-on-failure"]
+      "buildcmd": ["mkdir build", "cd build", "CXX=g++ cmake ..", "make -j", "ctest --output-on-failure"]
     },
     "fedora24-x86_64-clang": {
       "buildenv": "fedora24-x86_64",
       "builddeps": ["cmake", "make", "clang"],
-      "buildcmd": ["mkdir build", "cd build", "CXX=clang++ cmake ..", "cmake --build .", "ctest --output-on-failure"]
+      "buildcmd": ["mkdir build", "cd build", "CXX=clang++ cmake ..", "make -j", "ctest --output-on-failure"]
     },
     "fedora24-x86_64-g++-debug": {
       "buildenv": "fedora24-x86_64",
       "builddeps": ["cmake", "make", "clang"],
-      "buildcmd": ["mkdir build", "cd build", "CXX=g++ cmake -DCMAKE_BUILD_TYPE=Debug ..", "cmake --build .", "ctest --output-on-failure"]
+      "buildcmd": ["mkdir build", "cd build", "CXX=g++ cmake -DCMAKE_BUILD_TYPE=Debug ..", "make -j", "ctest --output-on-failure"]
     },
     "fedora24-x86_64-clang-debug": {
       "buildenv": "fedora24-x86_64",
       "builddeps": ["cmake", "make", "clang"],
-      "buildcmd": ["mkdir build", "cd build", "CXX=clang++ cmake -DCMAKE_BUILD_TYPE=Debug ..", "cmake --build .", "ctest --output-on-failure"]
+      "buildcmd": ["mkdir build", "cd build", "CXX=clang++ cmake -DCMAKE_BUILD_TYPE=Debug ..", "make -j", "ctest --output-on-failure"]
     },
     "fedora24-x86_64-g++-release": {
       "buildenv": "fedora24-x86_64",
       "builddeps": ["cmake", "make", "clang"],
-      "buildcmd": ["mkdir build", "cd build", "CXX=g++ cmake -DCMAKE_BUILD_TYPE=Release ..", "cmake --build .", "ctest --output-on-failure"]
+      "buildcmd": ["mkdir build", "cd build", "CXX=g++ cmake -DCMAKE_BUILD_TYPE=Release ..", "make -j", "ctest --output-on-failure"]
     },
     "fedora24-x86_64-clang-release": {
       "buildenv": "fedora24-x86_64",
       "builddeps": ["cmake", "make", "clang"],
-      "buildcmd": ["mkdir build", "cd build", "CXX=clang++ cmake -DCMAKE_BUILD_TYPE=Release ..", "cmake --build .", "ctest --output-on-failure"]
+      "buildcmd": ["mkdir build", "cd build", "CXX=clang++ cmake -DCMAKE_BUILD_TYPE=Release ..", "make -j", "ctest --output-on-failure"]
     },
     "osx": {
       "buildenv": "osx",
       "builddeps": ["build-essential"],
-      "buildcmd": "make -j ${PARALLEL}"
+      "buildcmd": "make -j"
     }
   }
 }


### PR DESCRIPTION
Just call make like 'make -j' for this to happen. When scheduling multiple
jobs on the same agent Doozer can act as jobserver for all 'make' jobs
and distribute load evenly between multiple parallel jobs.