### PR TITLE
Fix bug in Lua table parsing.

### DIFF
--- a/src/example/pegtl/lua53_parse.cpp
+++ b/src/example/pegtl/lua53_parse.cpp
@@ -205,8 +205,13 @@ namespace lua53
    template< typename E >
    struct statement_list : pegtl::seq< seps, pegtl::until< pegtl::sor< E, pegtl::if_must< key_return, statement_return, E > >, statement, seps > > {};
 
+   template< char O, char... N >
+   struct op_one : pegtl::seq< pegtl::one< O >, pegtl::at< pegtl::not_one< N... > > > {};
+   template< char O, char P, char... N >
+   struct op_two : pegtl::seq< pegtl::string< O, P >, pegtl::at< pegtl::not_one< N... > > > {};
+
    struct table_field_one : pegtl::if_must< pegtl::one< '[' >, seps, expression, seps, pegtl::one< ']' >, seps, pegtl::one< '=' >, seps, expression > {};
-   struct table_field_two : pegtl::if_must< pegtl::seq< name, seps, pegtl::one< '=' > >, seps, expression > {};
+   struct table_field_two : pegtl::if_must< pegtl::seq< name, seps, op_one< '=', '=' > >, seps, expression > {};
    struct table_field : pegtl::sor< table_field_one, table_field_two, expression > {};
    struct table_field_list : pegtl::list_tail< table_field, pegtl::one< ',', ';' >, sep > {};
    struct table_constructor : pegtl::if_must< pegtl::one< '{' >, pegtl::pad_opt< table_field_list, sep >, pegtl::one< '}' > > {};
@@ -236,11 +241,6 @@ namespace lua53
 
    struct variable : pegtl::seq< variable_head, pegtl::star< pegtl::star< seps, function_call_tail >, seps, variable_tail > > {};
    struct function_call : pegtl::seq< function_call_head, pegtl::plus< pegtl::until< pegtl::seq< seps, function_call_tail >, seps, variable_tail > > > {};
-
-   template< char O, char... N >
-   struct op_one : pegtl::seq< pegtl::one< O >, pegtl::at< pegtl::not_one< N... > > > {};
-   template< char O, char P, char... N >
-   struct op_two : pegtl::seq< pegtl::string< O, P >, pegtl::at< pegtl::not_one< N... > > > {};
 
    template< typename S, typename O >
    struct left_assoc : pegtl::seq< S, seps, pegtl::star< pegtl::if_must< O, seps, S, seps > > > {};


### PR DESCRIPTION
The parser was unable to parse “{a==0}” because it believed “a=” was the
beginning of a table constructor field initializer. This is fixed by
disallowing “==” when matching “=”.