### PR TITLE
Make sure we are not accessing a non-existent child.

### DIFF
--- a/src/example/pegtl/parse_tree.cpp
+++ b/src/example/pegtl/parse_tree.cpp
@@ -80,6 +80,9 @@ namespace example
       static void rearrange( std::unique_ptr< parse_tree::node >& n )
       {
          auto& c = n->children;
+         if( c.empty() ) {
+            return;
+         }
          if( c.size() == 1 ) {
             n = std::move( c.back() );
          }


### PR DESCRIPTION
This checks that `children` is not empty so calling `c.back()` later can not fail. Otherwise we crash for something like `1+2+`.