### PR TITLE
Bugfix for doubles example

### DIFF
--- a/src/example/pegtl/double.hpp
+++ b/src/example/pegtl/double.hpp
@@ -35,9 +35,9 @@ namespace double_
    struct exponent : seq< plus_minus, plus< digit > > {};
 
    struct decimal : seq< number< digit >, opt< e, exponent > > {};
-   struct binary : seq< one< '0' >, one< 'x', 'X' >, number< xdigit >, opt< p, exponent > > {};
+   struct hexadecimal : seq< one< '0' >, one< 'x', 'X' >, number< xdigit >, opt< p, exponent > > {};
 
-   struct grammar : seq< plus_minus, sor< decimal, binary, inf, nan > > {};
+   struct grammar : seq< plus_minus, sor< hexadecimal, decimal, inf, nan > > {};
    // clang-format on
 
 }  // double_


### PR DESCRIPTION
The doubles example (sum.cpp, doubles.hpp) wasn't recognizing hexadecimal numbers. A simple swap of the binary and decimal rules seems to do the trick. Also, I changed the name of the binary rule to hexadecimal, since that's what it actually matches.