### PR TITLE
Update Contrib-and-Examples.md

### DIFF
--- a/doc/Contrib-and-Examples.md
+++ b/doc/Contrib-and-Examples.md
@@ -108,7 +108,7 @@ Reads a file with an [ABNF (RFC 5234)](https://tools.ietf.org/html/rfc5234)-styl
 
 ###### `src/example/pegtl/analyze.cpp`
 
-A small example that provokes the [grammar analysis](Grammar-Analisys.md) to find problems.
+A small example that provokes the [grammar analysis](Grammar-Analysis.md) to find problems.
 
 ###### `src/example/pegtl/calculator.cpp`
 


### PR DESCRIPTION
FIXES link to Grammar-Analysis.md (was Grammar-Analisys.md)