### PR TITLE
Add missing inline to avoid linking error.

### DIFF
--- a/include/tao/pegtl/internal/file_reader.hpp
+++ b/include/tao/pegtl/internal/file_reader.hpp
@@ -18,7 +18,7 @@ namespace tao
    {
       namespace internal
       {
-         std::FILE* file_open( const char* filename )
+         inline std::FILE* file_open( const char* filename )
          {
             errno = 0;
 #if defined( _MSC_VER )


### PR DESCRIPTION
If I `#include <tao/pegtl.hpp>` in more than one source code file and link them together, I get this error:

```
../lib/liblibneopg.a(http.cpp.o): In function `std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >::_M_data() const':
/home/marcus/projects/neopg/neopg/3rdparty/pegtl/include/tao/pegtl/internal/file_reader.hpp:22: multiple definition of `tao::pegtl::internal::file_open(char const*)'
../lib/liblibneopg.a(uri.cpp.o):/home/marcus/projects/neopg/neopg/3rdparty/pegtl/include/tao/pegtl/internal/file_reader.hpp:22: first defined here
clang-4.0: error: linker command failed with exit code 1 (use -v to see invocation)
```

Adding the static helps. Is this the right fix for you?