### PR TITLE
Fix broken links

### DIFF
--- a/doc/Inputs-and-Parsing.md
+++ b/doc/Inputs-and-Parsing.md
@@ -222,7 +222,7 @@ The parse functions accept the following template parameters and arguments:
 - The [`Rule` class](Rules-and-Grammars.md) represents the top-level parsing rule of the grammar and is mandatory.
 - The [`Action<>` class template](Actions-and-States.md) is required to actually do something during a parsing run.
 - The [`Control<>` class template](Control-and-Debug.md) is only required for grammar debugging or some advanced uses.
-- The [`States`](Actions-and-States) are the types of the objects that are passed to all actions and control hooks.
+- The [`States`](Actions-and-States.md#changing-states) are the types of the objects that are passed to all actions and control hooks.
 
 Additionally, two enumeration values can be used to control the behaviour:
 

--- a/doc/Rule-Reference.md
+++ b/doc/Rule-Reference.md
@@ -60,7 +60,7 @@ These rules are in namespace `tao::pegtl`.
 
 * Equivalent to `success`, but:
 * Calls the input's `discard()`-method.
-* See [Incremental Input](Incremental-Input.md) for details.
+* See [Incremental Input](Inputs-and-Parsing.md#incremental-input) for details.
 
 ###### `enable< R... >`
 
@@ -70,7 +70,7 @@ These rules are in namespace `tao::pegtl`.
 ###### `require< Num >`
 
 * Succeeds if at least `Num` further input bytes are available.
-* With [Incremental Input](Incremental-Input.md) reads the bytes into the buffer.
+* With [Incremental Input](Inputs-and-Parsing.md#incremental-input) reads the bytes into the buffer.
 
 ###### `state< S, R... >`
 


### PR DESCRIPTION
I checked with https://github.com/tcort/markdown-link-check. This is the sort of thing you probably could add to a CI check if you'd like. This should fix all of the currently broken links, minus a gentoo package link that just seems to be a server issue on their end right now.