### PR TITLE
Support Conan

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -1,9 +1,5 @@
 version: '{branch}-{build}'
 
-branches:
-  only:
-    - master
-
 os:
 - Visual Studio 2015
 

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -34,9 +34,19 @@ environment:
       COMPILER: MinGW 6
       BINDIR: C:\mingw-w64\x86_64-6.3.0-posix-seh-rt_v5-rev1\mingw64\bin
 
+    - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2017
+      GENERATOR: Visual Studio 15 2017
+      CONAN_VISUAL_VERSIONS: 15
+      PYTHON: "C:\\Python27"
+      PYTHON_VERSION: "2.7.8"
+      PYTHON_ARCH: "32"
+      CONAN: TRUE
+
 init: []
 
-install: []
+install:
+- if defined CONAN (set PATH=%PATH%;%PYTHON%/Scripts/)
+- if defined CONAN (pip.exe install -U conan conan-package-tools)
 
 before_build:
 - if "%APPVEYOR_BUILD_WORKER_IMAGE%"=="Visual Studio 2015" (del "C:\Program Files (x86)\MSBuild\14.0\Microsoft.Common.targets\ImportAfter\Xamarin.Common.targets")
@@ -50,3 +60,4 @@ build_script:
 
 test_script:
 - ctest -C "%CONFIGURATION%" --output-on-failure
+- if defined CONAN (python build.py)

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -45,8 +45,8 @@ environment:
 init: []
 
 install:
-- if defined CONAN (set PATH=%PATH%;%PYTHON%/Scripts/)
 - if defined CONAN (pip.exe install -U conan conan-package-tools)
+- if defined CONAN (conan profile new default --detect)
 
 before_build:
 - if "%APPVEYOR_BUILD_WORKER_IMAGE%"=="Visual Studio 2015" (del "C:\Program Files (x86)\MSBuild\14.0\Microsoft.Common.targets\ImportAfter\Xamarin.Common.targets")
@@ -60,4 +60,5 @@ build_script:
 
 test_script:
 - ctest -C "%CONFIGURATION%" --output-on-failure
+- if defined CONAN (cd ..)
 - if defined CONAN (python build.py)

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -1,5 +1,9 @@
 version: '{branch}-{build}'
 
+branches:
+  only:
+    - master
+
 os:
 - Visual Studio 2015
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -425,6 +425,18 @@ matrix:
         - "sed -i 's#TAO_PEGTL_NAMESPACE#pegtl#g' $(find . -name '*.[hc]pp')"
         - make -kj3 clang-tidy
 
+    - language: python
+      python:
+        - "3.6"
+      sudo: required
+      install:
+        - pip install conan conan-package-tools
+      env:
+        - CONAN_GCC_VERSIONS=7
+        - CONAN_DOCKER_IMAGE=lasote/conangcc7
+      script:
+        - python build.py
+
 script:
   - $CXX --version
   - make -kj3

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,10 +2,6 @@ language: generic
 os: linux
 dist: trusty
 
-branches:
-  only:
-    - master
-
 matrix:
   include:
     - compiler: gcc

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,10 @@ language: generic
 os: linux
 dist: trusty
 
+branches:
+  only:
+    - master
+
 matrix:
   include:
     - compiler: gcc

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,12 +2,6 @@ cmake_minimum_required (VERSION 3.2.0 FATAL_ERROR)
 
 project (pegtl VERSION 2.5.2 LANGUAGES CXX)
 
-# Build project by Conan
-if(EXISTS "${CMAKE_BINARY_DIR}/conanbuildinfo.cmake")
-    include("${CMAKE_BINARY_DIR}/conanbuildinfo.cmake")
-    conan_basic_setup()
-endif(EXISTS "${CMAKE_BINARY_DIR}/conanbuildinfo.cmake")
-
 # installation directories
 set (PEGTL_INSTALL_INCLUDE_DIR "include" CACHE STRING "The installation include directory")
 set (PEGTL_INSTALL_DOC_DIR "share/doc/tao/pegtl" CACHE STRING "The installation doc directory")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,6 +2,12 @@ cmake_minimum_required (VERSION 3.2.0 FATAL_ERROR)
 
 project (pegtl VERSION 2.5.2 LANGUAGES CXX)
 
+# Build project by Conan
+if(EXISTS "${CMAKE_BINARY_DIR}/conanbuildinfo.cmake")
+    include("${CMAKE_BINARY_DIR}/conanbuildinfo.cmake")
+    conan_basic_setup()
+endif(EXISTS "${CMAKE_BINARY_DIR}/conanbuildinfo.cmake")
+
 # installation directories
 set (PEGTL_INSTALL_INCLUDE_DIR "include" CACHE STRING "The installation include directory")
 set (PEGTL_INSTALL_DOC_DIR "share/doc/tao/pegtl" CACHE STRING "The installation doc directory")

--- a/build.py
+++ b/build.py
@@ -1,0 +1,29 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+
+import os
+from cpt.packager import ConanMultiPackager
+
+
+class BuilderSettings(object):
+    @property
+    def username(self):
+        return os.getenv("CONAN_USERNAME", "taocpp")
+
+    @property
+    def upload(self):
+        bintray_url = "https://api.bintray.com/conan/taocpp/public-conan"
+        return os.getenv("CONAN_UPLOAD", bintray_url)
+
+    @property
+    def upload_only_when_stable(self):
+        return os.getenv("CONAN_UPLOAD_ONLY_WHEN_STABLE", True)
+
+if __name__ == "__main__":
+    settings = BuilderSettings()
+    builder = ConanMultiPackager(
+        username=settings.username,
+        upload=settings.upload,
+        upload_only_when_stable=settings.upload_only_when_stable)
+    builder.add()
+    builder.run()

--- a/build.py
+++ b/build.py
@@ -2,28 +2,58 @@
 # -*- coding: utf-8 -*-
 
 import os
+import re
 from cpt.packager import ConanMultiPackager
 
 
 class BuilderSettings(object):
     @property
     def username(self):
+        """ Set taocpp as package's owner
+        """
         return os.getenv("CONAN_USERNAME", "taocpp")
 
     @property
     def upload(self):
+        """ Set taocpp repository to be used on upload
+        """
         bintray_url = "https://api.bintray.com/conan/taocpp/public-conan"
         return os.getenv("CONAN_UPLOAD", bintray_url)
 
     @property
     def upload_only_when_stable(self):
+        """ Force to upload when running over tag branch
+        """
         return os.getenv("CONAN_UPLOAD_ONLY_WHEN_STABLE", True)
+
+    @property
+    def stable_branch_pattern(self):
+        """ Only upload the package the branch name is like a tag
+        """
+        return os.getenv("CONAN_STABLE_BRANCH_PATTERN", r"\d+\.\d+\.\d+")
+
+    @property
+    def reference(self):
+        """ Read project version from CMake file to create Conan referece
+        """
+        pattern = re.compile(r"project \(pegtl VERSION (\d+\.\d+\.\d+) LANGUAGES CXX\)")
+        version = None
+        with open('CMakeLists.txt') as file:
+            for line in file:
+                result = pattern.match(line)
+                if result:
+                    version = result.group(1)
+        if not version:
+            raise Exception("Could not find version in CMakeLists.txt")
+        return os.getenv("CONAN_REFERENCE", "pegtl/{}@taocpp/stable".format(version))
 
 if __name__ == "__main__":
     settings = BuilderSettings()
     builder = ConanMultiPackager(
+        reference=settings.reference,
         username=settings.username,
         upload=settings.upload,
-        upload_only_when_stable=settings.upload_only_when_stable)
+        upload_only_when_stable=settings.upload_only_when_stable,
+        stable_branch_pattern=settings.stable_branch_pattern)
     builder.add()
     builder.run()

--- a/conanfile.py
+++ b/conanfile.py
@@ -4,7 +4,6 @@ from conans import ConanFile, CMake
 
 class PEGTLConan(ConanFile):
     name = "pegtl"
-    version = "2.5.2"
     description = "C++11 header-only parser combinator library for creating PEG parsers"
     homepage = "https://github.com/taocpp/PEGTL"
     url = homepage
@@ -24,10 +23,8 @@ class PEGTLConan(ConanFile):
         cmake.definitions["PEGTL_BUILD_TESTS"] = "OFF"
         cmake.definitions["PEGTL_BUILD_EXAMPLES"] = "OFF"
         cmake.definitions["PEGTL_INSTALL_DOC_DIR"] = "licenses"
-        cmake.definitions["PEGTL_INSTALL_CMAKE_DIR"] = self.package_folder
         cmake.configure()
         cmake.install()
-        cmake.patch_config_paths()
 
     def package_id(self):
         self.info.header_only()

--- a/conanfile.py
+++ b/conanfile.py
@@ -27,6 +27,7 @@ class PEGTLConan(ConanFile):
         cmake.definitions["PEGTL_INSTALL_CMAKE_DIR"] = self.package_folder
         cmake.configure()
         cmake.install()
+        cmake.patch_config_paths()
 
     def package_id(self):
         self.info.header_only()

--- a/conanfile.py
+++ b/conanfile.py
@@ -10,7 +10,7 @@ class PEGTLConan(ConanFile):
     url = homepage
     license = "MIT"
     author = "taocpp@icemx.net"
-    settings = "compiler"
+    settings = "compiler", "arch"
     exports = "LICENSE"
     exports_sources = "include/*", "CMakeLists.txt"
     generators = "cmake"

--- a/conanfile.py
+++ b/conanfile.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
-from conans import ConanFile
+from conans import ConanFile, CMake
 
 class PEGTLConan(ConanFile):
     name = "pegtl"
@@ -10,16 +10,23 @@ class PEGTLConan(ConanFile):
     url = homepage
     license = "MIT"
     author = "taocpp@icemx.net"
+    settings = "compiler"
     exports = "LICENSE"
-    exports_sources = "include/*"
+    exports_sources = "include/*", "CMakeLists.txt"
+    generators = "cmake"
     no_copy_source = True
 
     def build(self):
         pass
 
     def package(self):
-        self.copy(pattern="LICENSE", dst="licenses")
-        self.copy(pattern="*.hpp", dst="include", src="include")
+        cmake = CMake(self)
+        cmake.definitions["PEGTL_BUILD_TESTS"] = "OFF"
+        cmake.definitions["PEGTL_BUILD_EXAMPLES"] = "OFF"
+        cmake.definitions["PEGTL_INSTALL_DOC_DIR"] = "licenses"
+        cmake.definitions["PEGTL_INSTALL_CMAKE_DIR"] = self.package_folder
+        cmake.configure()
+        cmake.install()
 
     def package_id(self):
         self.info.header_only()

--- a/conanfile.py
+++ b/conanfile.py
@@ -1,14 +1,22 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
 from conans import ConanFile, CMake
-import os
 
 class PEGTLConan(ConanFile):
     name = "pegtl"
+    version = "2.5.2"
     description = "C++11 header-only parser combinator library for creating PEG parsers"
     homepage = "https://github.com/taocpp/PEGTL"
     url = homepage
     license = "MIT"
     author = "taocpp@icemx.net"
-    exports_sources = "include*", "LICENSE", "CMakeLists.txt"
+    exports = "LICENSE"
+    exports_sources = "include/*", "CMakeLists.txt"
+    generators = "cmake"
+    no_copy_source = True
+
+    def build(self):
+        pass
 
     def package(self):
         cmake = CMake(self)
@@ -16,6 +24,7 @@ class PEGTLConan(ConanFile):
         cmake.definitions["PEGTL_BUILD_TESTS"] = "OFF"
         cmake.definitions["PEGTL_BUILD_EXAMPLES"] = "OFF"
         cmake.definitions["PEGTL_INSTALL_DOC_DIR"] = "licenses"
+        cmake.definitions["PEGTL_INSTALL_CMAKE_DIR"] = self.package_folder
 
         cmake.configure()
         cmake.install()

--- a/conanfile.py
+++ b/conanfile.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
-from conans import ConanFile, CMake
+from conans import ConanFile
 
 class PEGTLConan(ConanFile):
     name = "pegtl"
@@ -11,23 +11,15 @@ class PEGTLConan(ConanFile):
     license = "MIT"
     author = "taocpp@icemx.net"
     exports = "LICENSE"
-    exports_sources = "include/*", "CMakeLists.txt"
-    generators = "cmake"
+    exports_sources = "include/*"
     no_copy_source = True
 
     def build(self):
         pass
 
     def package(self):
-        cmake = CMake(self)
-
-        cmake.definitions["PEGTL_BUILD_TESTS"] = "OFF"
-        cmake.definitions["PEGTL_BUILD_EXAMPLES"] = "OFF"
-        cmake.definitions["PEGTL_INSTALL_DOC_DIR"] = "licenses"
-        cmake.definitions["PEGTL_INSTALL_CMAKE_DIR"] = self.package_folder
-
-        cmake.configure()
-        cmake.install()
+        self.copy(pattern="LICENSE", dst="licenses")
+        self.copy(pattern="*.hpp", dst="include", src="include")
 
     def package_id(self):
         self.info.header_only()

--- a/test_package/CMakeLists.txt
+++ b/test_package/CMakeLists.txt
@@ -1,14 +1,13 @@
-project(test_package)
+project(test_package CXX)
 cmake_minimum_required(VERSION 3.2.0 FATAL_ERROR)
 
 set(CMAKE_VERBOSE_MAKEFILE TRUE)
 
-set(CMAKE_CXX_STANDARD 11)
-
 include(${CMAKE_BINARY_DIR}/conanbuildinfo.cmake)
 conan_basic_setup()
 
-file(GLOB SOURCE_FILES *.cpp)
+find_package(PEGTL REQUIRED CONFIG)
 
-add_executable(${PROJECT_NAME} ${SOURCE_FILES})
+add_executable(${PROJECT_NAME} test_package.cpp)
 target_link_libraries(${PROJECT_NAME} ${CONAN_LIBS})
+set_property(TARGET ${PROJECT_NAME} PROPERTY CXX_STANDARD 11)

--- a/test_package/CMakeLists.txt
+++ b/test_package/CMakeLists.txt
@@ -6,6 +6,7 @@ set(CMAKE_VERBOSE_MAKEFILE TRUE)
 include(${CMAKE_BINARY_DIR}/conanbuildinfo.cmake)
 conan_basic_setup()
 
+find_package(PEGTL REQUIRED CONFIG)
+
 add_executable(${PROJECT_NAME} test_package.cpp)
-target_link_libraries(${PROJECT_NAME} ${CONAN_LIBS})
-set_property(TARGET ${PROJECT_NAME} PROPERTY CXX_STANDARD 11)
+target_link_libraries(${PROJECT_NAME} taocpp::pegtl)

--- a/test_package/CMakeLists.txt
+++ b/test_package/CMakeLists.txt
@@ -6,8 +6,6 @@ set(CMAKE_VERBOSE_MAKEFILE TRUE)
 include(${CMAKE_BINARY_DIR}/conanbuildinfo.cmake)
 conan_basic_setup()
 
-find_package(PEGTL REQUIRED CONFIG)
-
 add_executable(${PROJECT_NAME} test_package.cpp)
 target_link_libraries(${PROJECT_NAME} ${CONAN_LIBS})
 set_property(TARGET ${PROJECT_NAME} PROPERTY CXX_STANDARD 11)


### PR DESCRIPTION
Related issue: #111 

I dont have permission to create branches on taocpp, because I have member role. But no problem, I just forked the project.

This PR just update the support to use Conan + PEGTL

I added a job for Travis and Appeveyor to validate on both platforms

Why I copied the files instead to use cmake helper?  
The cmake helper requires settings.compiler when run over Windows, but this package is header-only and no settings is required. In the future I'll provide FindPEGTL.cmake file, so don't worry.

The next step is update Travis settings. I don't have permission to change the project settings on Travis :( But you need to add `CONAN_LOGIN_USERNAME` as taocpp-user, and `CONAN_PASSWORD` with Key API provided by Bintray.

Regards!