### PR TITLE
Add Win32 memory mapped file support

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -34,7 +34,7 @@ CXXFLAGS ?= -Wall -Wextra -Wshadow -Werror -O3 $(MINGW_CXXFLAGS)
 
 CLANG_TIDY ?= clang-tidy
 
-HEADERS := $(filter-out include/tao/pegtl/internal/endian_win.hpp,$(shell find include -name '*.hpp')) $(filter-out src/test/pegtl/main.hpp,$(shell find src -name '*.hpp'))
+HEADERS := $(filter-out include/tao/pegtl/internal/endian_win.hpp include/tao/pegtl/internal/win32_file_mapper.hpp,$(shell find include -name '*.hpp')) $(filter-out src/test/pegtl/main.hpp,$(shell find src -name '*.hpp'))
 SOURCES := $(shell find src -name '*.cpp')
 DEPENDS := $(SOURCES:%.cpp=build/%.d)
 BINARIES := $(SOURCES:%.cpp=build/%)

--- a/include/tao/pegtl/file_input.hpp
+++ b/include/tao/pegtl/file_input.hpp
@@ -12,7 +12,7 @@
 #include <unistd.h>  // Required for _POSIX_MAPPED_FILES
 #endif
 
-#if defined( _POSIX_MAPPED_FILES )
+#if defined( _POSIX_MAPPED_FILES ) || defined( _WIN32 )
 #include "mmap_input.hpp"
 #else
 #include "read_input.hpp"
@@ -22,7 +22,7 @@ namespace tao
 {
    namespace TAO_PEGTL_NAMESPACE
    {
-#if defined( _POSIX_MAPPED_FILES )
+#if defined( _POSIX_MAPPED_FILES ) || defined( _WIN32 )
       template< tracking_mode P = tracking_mode::IMMEDIATE, typename Eol = eol::lf_crlf >
       using file_input = mmap_input< P, Eol >;
 #else

--- a/include/tao/pegtl/input_error.hpp
+++ b/include/tao/pegtl/input_error.hpp
@@ -40,4 +40,12 @@ namespace tao
       throw tao::TAO_PEGTL_NAMESPACE::input_error( oss.str(), errorno );                \
    } while( false )
 
+#define TAO_PEGTL_THROW_INPUT_WIN32_ERROR( MESSAGE )                                             \
+   do {                                                                                          \
+      const int errorno = GetLastError();                                                        \
+      std::ostringstream oss;                                                                    \
+      oss << "pegtl: " << TAO_PEGTL_INTERNAL_UNWRAP( MESSAGE ) << " GetLastError() " << errorno; \
+      throw tao::TAO_PEGTL_NAMESPACE::input_error( oss.str(), errorno );                         \
+   } while( false )
+
 #endif

--- a/include/tao/pegtl/internal/win32_file_mapper.hpp
+++ b/include/tao/pegtl/internal/win32_file_mapper.hpp
@@ -1,0 +1,193 @@
+// Copyright (c) 2014-2018 Dr. Colin Hirsch and Daniel Frey
+// Please see LICENSE for license or visit https://github.com/taocpp/PEGTL/
+
+#ifndef TAO_PEGTL_INTERNAL_WIN32_FILE_MAPPER_HPP
+#define TAO_PEGTL_INTERNAL_WIN32_FILE_MAPPER_HPP
+
+#define NOMINMAX
+#define WIN32_MEAN_AND_LEAN
+#include <Windows.h>
+#undef NOMINMAX
+#undef WIN32_MEAN_AND_LEAN
+
+#include "../config.hpp"
+
+#include "../input_error.hpp"
+
+namespace tao
+{
+   namespace TAO_PEGTL_NAMESPACE
+   {
+      namespace internal
+      {
+         struct win32_file_opener
+         {
+            explicit win32_file_opener( const char* filename )
+               : m_source( filename ),
+                 m_handle( open() )
+            {
+            }
+
+            win32_file_opener( const win32_file_opener& ) = delete;
+            win32_file_opener( win32_file_opener&& ) = delete;
+
+            ~win32_file_opener() noexcept
+            {
+               ::CloseHandle( m_handle );
+            }
+
+            void operator=( const win32_file_opener& ) = delete;
+            void operator=( win32_file_opener&& ) = delete;
+
+            std::size_t size() const
+            {
+               LARGE_INTEGER size;
+               if(::GetFileSizeEx( m_handle, &size ) < 0 ) {
+                  TAO_PEGTL_THROW_INPUT_WIN32_ERROR( "unable to GetFileSizeEx() file " << m_source << " handle " << m_handle );
+               }
+               return std::size_t( size.QuadPart );
+            }
+
+            const char* const m_source;
+            const HANDLE m_handle;
+
+         private:
+            HANDLE open() const
+            {
+               SetLastError( 0 );
+               const HANDLE handle = ::CreateFileA( m_source,  // NOLINT
+                                                    GENERIC_READ,
+                                                    FILE_SHARE_READ,
+                                                    nullptr,
+                                                    OPEN_EXISTING,
+                                                    FILE_ATTRIBUTE_NORMAL,
+                                                    nullptr );
+               if( handle != INVALID_HANDLE_VALUE ) {
+                  return handle;
+               }
+               TAO_PEGTL_THROW_INPUT_WIN32_ERROR( "unable to CreateFileA() file " << m_source << " for reading" );
+            }
+         };
+
+         struct win32_file_mapper
+         {
+            explicit win32_file_mapper( const char* filename )
+               : win32_file_mapper( win32_file_opener( filename ) )
+            {
+            }
+
+            explicit win32_file_mapper( const win32_file_opener& reader )
+               : m_size( reader.size() ),
+                 m_handle( open( reader ) )
+            {
+            }
+
+            win32_file_mapper( const win32_file_mapper& ) = delete;
+            win32_file_mapper( win32_file_mapper&& ) = delete;
+
+            ~win32_file_mapper() noexcept
+            {
+               ::CloseHandle( m_handle );
+            }
+
+            void operator=( const win32_file_mapper& ) = delete;
+            void operator=( win32_file_mapper&& ) = delete;
+
+            const size_t m_size;
+            const HANDLE m_handle;
+
+         private:
+            HANDLE open( const win32_file_opener& reader ) const
+            {
+               const uint64_t file_size = reader.size();
+               SetLastError( 0 );
+               const HANDLE handle = ::CreateFileMappingA( reader.m_handle,
+                                                           nullptr,
+                                                           PAGE_READONLY,
+                                                           DWORD( file_size >> 32 ),
+                                                           DWORD( file_size & 0xffffffff ),
+                                                           nullptr );
+               if( handle != NULL ) {
+                  return handle;
+               }
+               TAO_PEGTL_THROW_INPUT_WIN32_ERROR( "unable to CreateFileMappingA() file " << reader.m_source << " for reading" );
+            }
+         };
+
+         class file_mapper
+         {
+         public:
+            explicit file_mapper( const char* filename )
+               : file_mapper( win32_file_mapper( filename ) )
+            {
+            }
+
+            explicit file_mapper( const win32_file_mapper& mapper )
+               : m_size( mapper.m_size ),
+                 m_data( static_cast< const char* const >(::MapViewOfFile( mapper.m_handle,
+                                                                           FILE_MAP_READ,
+                                                                           0,
+                                                                           0,
+                                                                           0 ) ) )
+            {
+               if( ( m_size != 0 ) && ( intptr_t( m_data ) == 0 ) ) {
+                  TAO_PEGTL_THROW_INPUT_WIN32_ERROR( "unable to MapViewOfFile() file mapping object with handle " << mapper.m_handle );
+               }
+            }
+
+            file_mapper( const file_mapper& ) = delete;
+            file_mapper( file_mapper&& ) = delete;
+
+            ~file_mapper() noexcept
+            {
+               ::UnmapViewOfFile( LPCVOID( m_data ) );
+            }
+
+            void operator=( const file_mapper& ) = delete;
+            void operator=( file_mapper&& ) = delete;
+
+            bool empty() const noexcept
+            {
+               return m_size == 0;
+            }
+
+            std::size_t size() const noexcept
+            {
+               return m_size;
+            }
+
+            using iterator = const char*;
+            using const_iterator = const char*;
+
+            iterator data() const noexcept
+            {
+               return m_data;
+            }
+
+            iterator begin() const noexcept
+            {
+               return m_data;
+            }
+
+            iterator end() const noexcept
+            {
+               return m_data + m_size;
+            }
+
+            std::string string() const
+            {
+               return std::string( m_data, m_size );
+            }
+
+         private:
+            const std::size_t m_size;
+            const char* const m_data;
+         };
+
+      }  // namespace internal
+
+   }  // namespace TAO_PEGTL_NAMESPACE
+
+}  // namespace tao
+
+#endif

--- a/include/tao/pegtl/internal/win32_file_mapper.hpp
+++ b/include/tao/pegtl/internal/win32_file_mapper.hpp
@@ -123,7 +123,7 @@ namespace tao
                                                            DWORD( file_size >> 32 ),
                                                            DWORD( file_size & 0xffffffff ),
                                                            nullptr );
-               if( handle != NULL ) {
+               if( handle != NULL || file_size == 0 ) {
                   return handle;
                }
                TAO_PEGTL_THROW_INPUT_WIN32_ERROR( "unable to CreateFileMappingW() file " << reader.m_source << " for reading" );

--- a/include/tao/pegtl/internal/win32_file_mapper.hpp
+++ b/include/tao/pegtl/internal/win32_file_mapper.hpp
@@ -4,17 +4,34 @@
 #ifndef TAO_PEGTL_INTERNAL_WIN32_FILE_MAPPER_HPP
 #define TAO_PEGTL_INTERNAL_WIN32_FILE_MAPPER_HPP
 
+#if !defined( NOMINMAX )
 #define NOMINMAX
+#define TAO_PEGTL_INTERNAL_WIN32_FILE_MAPPER_HPP_NOMINMAX_WAS_DEFINED
+#endif
+#if defined( WIN32_LEAN_AND_MEAN )
 #define WIN32_MEAN_AND_LEAN
-#if defined( _M_IX86 ) && !defined( _AMD64_ )
+#define TAO_PEGTL_INTERNAL_WIN32_FILE_MAPPER_HPP_WIN32_MEAN_AND_LEAN_WAS_DEFINED
+#endif
+#if !defined( _X86_ ) && defined( _M_IX86 ) && !defined( _AMD64_ )
 #define _X86_
+#define TAO_PEGTL_INTERNAL_WIN32_FILE_MAPPER_HPP_X86_WAS_DEFINED
 #endif
 #include <errhandlingapi.h>  // For GetLastError, SetLastError
 #include <fileapi.h>         // For CreateFileA
 #include <handleapi.h>       // For CloseHandle
 #include <memoryapi.h>       // For CreateFileMappingW, MapViewOfFile, UnmapViewOfFile
+#if defined( TAO_PEGTL_INTERNAL_WIN32_FILE_MAPPER_HPP_NOMINMAX_WAS_DEFINED )
 #undef NOMINMAX
+#undef TAO_PEGTL_INTERNAL_WIN32_FILE_MAPPER_HPP_NOMINMAX_WAS_DEFINED
+#endif
+#if defined( TAO_PEGTL_INTERNAL_WIN32_FILE_MAPPER_HPP_WIN32_MEAN_AND_LEAN_WAS_DEFINED )
 #undef WIN32_MEAN_AND_LEAN
+#undef TAO_PEGTL_INTERNAL_WIN32_FILE_MAPPER_HPP_WIN32_MEAN_AND_LEAN_WAS_DEFINED
+#endif
+#if defined( TAO_PEGTL_INTERNAL_WIN32_FILE_MAPPER_HPP_X86_WAS_DEFINED )
+#undef _X86_
+#undef TAO_PEGTL_INTERNAL_WIN32_FILE_MAPPER_HPP_X86_WAS_DEFINED
+#endif
 
 #include "../config.hpp"
 

--- a/include/tao/pegtl/internal/win32_file_mapper.hpp
+++ b/include/tao/pegtl/internal/win32_file_mapper.hpp
@@ -6,7 +6,13 @@
 
 #define NOMINMAX
 #define WIN32_MEAN_AND_LEAN
-#include <Windows.h>
+#if defined( _M_IX86 ) && !defined( _AMD64_ )
+#define _X86_
+#endif
+// #include <errhandlingapi.h>  // For GetLastError, SetLastError
+// #include <fileapi.h>         // For CreateFileA
+// #include <handleapi.h>       // For CloseHandle
+// #include <memoryapi.h>       // For CreateFileMappingW, MapViewOfFile, UnmapViewOfFile
 #undef NOMINMAX
 #undef WIN32_MEAN_AND_LEAN
 
@@ -101,7 +107,11 @@ namespace tao
             {
                const uint64_t file_size = reader.size();
                SetLastError( 0 );
-               const HANDLE handle = ::CreateFileMappingA( reader.m_handle,
+               // Use `CreateFileMappingW` because a) we're not specifying a
+               // mapping name, so the character type is of no consequence, and
+               // b) it's defined in `memoryapi.h`, unlike
+               // `CreateFileMappingA`(?!)
+               const HANDLE handle = ::CreateFileMappingW( reader.m_handle,
                                                            nullptr,
                                                            PAGE_READONLY,
                                                            DWORD( file_size >> 32 ),
@@ -110,7 +120,7 @@ namespace tao
                if( handle != NULL ) {
                   return handle;
                }
-               TAO_PEGTL_THROW_INPUT_WIN32_ERROR( "unable to CreateFileMappingA() file " << reader.m_source << " for reading" );
+               TAO_PEGTL_THROW_INPUT_WIN32_ERROR( "unable to CreateFileMappingW() file " << reader.m_source << " for reading" );
             }
          };
 

--- a/include/tao/pegtl/internal/win32_file_mapper.hpp
+++ b/include/tao/pegtl/internal/win32_file_mapper.hpp
@@ -8,18 +8,11 @@
 #define NOMINMAX
 #define TAO_PEGTL_INTERNAL_WIN32_FILE_MAPPER_HPP_NOMINMAX_WAS_DEFINED
 #endif
-#if defined( WIN32_LEAN_AND_MEAN )
+#if !defined( WIN32_LEAN_AND_MEAN )
 #define WIN32_MEAN_AND_LEAN
 #define TAO_PEGTL_INTERNAL_WIN32_FILE_MAPPER_HPP_WIN32_MEAN_AND_LEAN_WAS_DEFINED
 #endif
-#if !defined( _X86_ ) && defined( _M_IX86 ) && !defined( _AMD64_ )
-#define _X86_
-#define TAO_PEGTL_INTERNAL_WIN32_FILE_MAPPER_HPP_X86_WAS_DEFINED
-#endif
-#include <errhandlingapi.h>  // For GetLastError, SetLastError
-#include <fileapi.h>         // For CreateFileA
-#include <handleapi.h>       // For CloseHandle
-#include <memoryapi.h>       // For CreateFileMappingW, MapViewOfFile, UnmapViewOfFile
+#include <Windows.h>
 #if defined( TAO_PEGTL_INTERNAL_WIN32_FILE_MAPPER_HPP_NOMINMAX_WAS_DEFINED )
 #undef NOMINMAX
 #undef TAO_PEGTL_INTERNAL_WIN32_FILE_MAPPER_HPP_NOMINMAX_WAS_DEFINED
@@ -27,10 +20,6 @@
 #if defined( TAO_PEGTL_INTERNAL_WIN32_FILE_MAPPER_HPP_WIN32_MEAN_AND_LEAN_WAS_DEFINED )
 #undef WIN32_MEAN_AND_LEAN
 #undef TAO_PEGTL_INTERNAL_WIN32_FILE_MAPPER_HPP_WIN32_MEAN_AND_LEAN_WAS_DEFINED
-#endif
-#if defined( TAO_PEGTL_INTERNAL_WIN32_FILE_MAPPER_HPP_X86_WAS_DEFINED )
-#undef _X86_
-#undef TAO_PEGTL_INTERNAL_WIN32_FILE_MAPPER_HPP_X86_WAS_DEFINED
 #endif
 
 #include "../config.hpp"

--- a/include/tao/pegtl/internal/win32_file_mapper.hpp
+++ b/include/tao/pegtl/internal/win32_file_mapper.hpp
@@ -9,10 +9,10 @@
 #if defined( _M_IX86 ) && !defined( _AMD64_ )
 #define _X86_
 #endif
-// #include <errhandlingapi.h>  // For GetLastError, SetLastError
-// #include <fileapi.h>         // For CreateFileA
-// #include <handleapi.h>       // For CloseHandle
-// #include <memoryapi.h>       // For CreateFileMappingW, MapViewOfFile, UnmapViewOfFile
+#include <errhandlingapi.h>  // For GetLastError, SetLastError
+#include <fileapi.h>         // For CreateFileA
+#include <handleapi.h>       // For CloseHandle
+#include <memoryapi.h>       // For CreateFileMappingW, MapViewOfFile, UnmapViewOfFile
 #undef NOMINMAX
 #undef WIN32_MEAN_AND_LEAN
 

--- a/include/tao/pegtl/internal/win32_file_mapper.hpp
+++ b/include/tao/pegtl/internal/win32_file_mapper.hpp
@@ -67,7 +67,7 @@ namespace tao
             HANDLE open() const
             {
                SetLastError( 0 );
-               const HANDLE handle = ::CreateFileA( m_source,  // NOLINT
+               const HANDLE handle = ::CreateFileA( m_source,
                                                     GENERIC_READ,
                                                     FILE_SHARE_READ,
                                                     nullptr,

--- a/include/tao/pegtl/internal/win32_file_mapper.hpp
+++ b/include/tao/pegtl/internal/win32_file_mapper.hpp
@@ -54,7 +54,7 @@ namespace tao
             std::size_t size() const
             {
                LARGE_INTEGER size;
-               if(::GetFileSizeEx( m_handle, &size ) < 0 ) {
+               if( !::GetFileSizeEx( m_handle, &size ) ) {
                   TAO_PEGTL_THROW_INPUT_WIN32_ERROR( "unable to GetFileSizeEx() file " << m_source << " handle " << m_handle );
                }
                return std::size_t( size.QuadPart );

--- a/include/tao/pegtl/mmap_input.hpp
+++ b/include/tao/pegtl/mmap_input.hpp
@@ -12,12 +12,10 @@
 #include "memory_input.hpp"
 #include "tracking_mode.hpp"
 
-#if defined( _POSIX_MAPPED_FILES )
-#include "internal/file_mapper.hpp"
-#elif defined( _WIN32 )
+#if defined( _WIN32 )
 #include "internal/win32_file_mapper.hpp"
 #else
-#error "This file should only be included if _POSIX_MAPPED_FILES or _WIN32 is defined"
+#include "internal/file_mapper.hpp"
 #endif
 
 namespace tao

--- a/include/tao/pegtl/mmap_input.hpp
+++ b/include/tao/pegtl/mmap_input.hpp
@@ -12,7 +12,13 @@
 #include "memory_input.hpp"
 #include "tracking_mode.hpp"
 
+#if defined( _POSIX_MAPPED_FILES )
 #include "internal/file_mapper.hpp"
+#elif defined( _WIN32 )
+#include "internal/win32_file_mapper.hpp"
+#else
+#error "This file should only be included if _POSIX_MAPPED_FILES or _WIN32 is defined"
+#endif
 
 namespace tao
 {

--- a/src/test/pegtl/file_mmap.cpp
+++ b/src/test/pegtl/file_mmap.cpp
@@ -4,7 +4,7 @@
 // this include gives us _POSIX_MAPPED_FILES to test and mmap_input<> if it is set
 #include <tao/pegtl/file_input.hpp>
 
-#if defined( _POSIX_MAPPED_FILES )
+#if defined( _POSIX_MAPPED_FILES ) || defined( _WIN32 )
 
 #include "test.hpp"
 #include "verify_file.hpp"


### PR DESCRIPTION
I've added the Win32 equivalent of Unix `mmap` support, using the equivalent set of Win32 functions (`CreateFileA`, followed by `CreateFileMappingA` and finally `MapViewOfFile`. I've added a header (`win32_file_mapper.hpp`) which contains RAII classes for the resources opened by these 3 functions (`win32_file_opener` => `CreateFileA`, manages a Win32 `HANDLE`, `win32_file_mapper` => `CreateFileMappingA`, manages a Win32 `HANDLE`, and then `file_mapper` => `MapViewOfFile`, manages the pointer that is the handle for the mapped view). I didn't want to add header files for the 'private' classes (`win32_file_opener` and `win32_file_mapper`), as they're only going to be used by `file_mapper`.

Other than that, the changes are:

1. `file_input.hpp`, `mmap_input.hpp`, `file_mmap.hpp` - enable mmap support if the macro `_WIN32` is defined (as it will be by MSVC & (I'm pretty sure)MINGW32).

2. `input_error.hpp` - add a macro to throw an `input_error` with the result of `GetLastError()` (the Win32 equivalent of `errno`). This is used only within `win32_file_mapper.hpp`).