### PR TITLE
typo fixed in doc

### DIFF
--- a/doc/Rule-Reference.md
+++ b/doc/Rule-Reference.md
@@ -494,7 +494,7 @@ can be matched by either `tao::pegtl::ascii::string< 0xe2, 0x82, 0xac >` or `tao
 ###### `space`
 
 * Matches and consumes a single space, line-feed, carriage-return, horizontal-tab, vertical-tab or form-feed.
-* Equivalent to `one< ' ', '\n', '\r', 't', '\v', '\f' >`.
+* Equivalent to `one< ' ', '\n', '\r', '\t', '\v', '\f' >`.
 
 ###### `string< C... >`
 


### PR DESCRIPTION
space was referred as equivalent to one< ..., 't', ... > instead of one< ..., '\t', ... >