### PR TITLE
Add final argument for internal `parse_tree` state to `make_control` functions: VS 2015 support

### DIFF
--- a/include/tao/pegtl/contrib/parse_tree.hpp
+++ b/include/tao/pegtl/contrib/parse_tree.hpp
@@ -6,6 +6,9 @@
 
 #include <cassert>
 #include <memory>
+#if defined(_MSC_VER) && _MSC_VER == 1900
+#include <tuple>
+#endif
 #include <type_traits>
 #include <typeinfo>
 #include <utility>
@@ -252,6 +255,89 @@ namespace tao
             struct make_control< Node, Selector, Control >::control< Rule, false, true >
                : Control< Rule >
             {
+#if defined(_MSC_VER) && _MSC_VER == 1900
+               template< typename Input, std::size_t... Is, typename... States >
+               static void start_impl( const Input& in, std::index_sequence< Is... >, States&&... st ) noexcept( noexcept( Control< Rule >::start( in, std::get< Is >( std::forward_as_tuple ( st... ) )... ) ) )
+               {
+                  std::get< sizeof...(st) - 1 >( std::forward_as_tuple( st... ) ); // silence C4100
+                  Control< Rule >::start( in, std::get< Is >( std::forward_as_tuple ( st... ) )... );
+               }
+
+               template< typename Input, typename... States >
+               static void start( const Input& in, States&&... st ) noexcept( noexcept( start_impl( in, std::make_index_sequence< sizeof...( st ) - 1 >{}, std::forward< States >( st )... ) ) )
+               {
+                  start_impl( in, std::make_index_sequence< sizeof...( st ) - 1 >{}, std::forward< States >( st )... );
+               }
+
+               template< typename Input, std::size_t... Is, typename... States >
+               static void success_impl( const Input& in, std::index_sequence< Is... >, States&&... st ) noexcept( noexcept( Control< Rule >::success( in, std::get< Is >( std::forward_as_tuple ( st... ) )... ) ) )
+               {
+                  std::get< sizeof...(st) - 1 >( std::forward_as_tuple( st... ) ); // silence C4100
+                  Control< Rule >::success( in, std::get< Is >( std::forward_as_tuple ( st... ) )... );
+               }
+
+               template< typename Input, typename... States >
+               static void success( const Input& in, States&&... st ) noexcept( noexcept( success_impl( in, std::make_index_sequence< sizeof...( st ) - 1 >{}, std::forward< States >( st )... ) ) )
+               {
+                  success_impl( in, std::make_index_sequence< sizeof...( st ) - 1 >{}, std::forward< States >( st )... );
+               }
+
+               template< typename Input, std::size_t... Is, typename... States >
+               static void failure_impl( const Input& in, std::index_sequence< Is... >, States&&... st ) noexcept( noexcept( Control< Rule >::failure( in, std::get< Is >( std::forward_as_tuple ( st... ) )... ) ) )
+               {
+                  std::get< sizeof...(st) - 1 >( std::forward_as_tuple( st... ) ); // silence C4100
+                  Control< Rule >::failure( in, std::get< Is >( std::forward_as_tuple ( st... ) )... );
+               }
+
+               template< typename Input, typename... States >
+               static void failure( const Input& in, States&&... st ) noexcept( noexcept( failure_impl( in, std::make_index_sequence< sizeof...( st ) - 1 >{}, std::forward< States >( st )... ) ) )
+               {
+                  failure_impl( in, std::make_index_sequence< sizeof...( st ) - 1 >{}, std::forward< States >( st )... );
+               }
+
+               template< typename Input, std::size_t... Is, typename... States >
+               static void raise_impl( const Input& in, std::index_sequence< Is... >, States&&... st ) noexcept( noexcept( Control< Rule >::raise( in, std::get< Is >( std::forward_as_tuple ( st... ) )... ) ) )
+               {
+                  std::get< sizeof...(st) - 1 >( std::forward_as_tuple( st... ) ); // silence C4100
+                  Control< Rule >::raise( in, std::get< Is >( std::forward_as_tuple ( st... ) )... );
+               }
+
+               template< typename Input, typename... States >
+               static void raise( const Input& in, States&&... st ) noexcept( noexcept( raise_impl( in, std::make_index_sequence< sizeof...( st ) - 1 >{}, std::forward< States >( st )... ) ) )
+               {
+                  raise_impl( in, std::make_index_sequence< sizeof...( st ) - 1 >{}, std::forward< States >( st )... );
+               }
+
+               template< template< typename... > class Action, typename Input, std::size_t... Is, typename... States >
+               static auto apply0_impl( const Input& in, std::index_sequence< Is... >, States&&... st ) noexcept( noexcept( Control< Rule >::template apply0< Action >( in, std::get< Is >( std::forward_as_tuple ( st... ) )... ) ) )
+                  -> decltype( auto )
+               {
+                  std::get< sizeof...(st) - 1 >( std::forward_as_tuple( st... ) ); // silence C4100
+                  return Control< Rule >::template apply0< Action >( in, std::get< Is >( std::forward_as_tuple ( st... ) )... );
+               }
+
+               template< template< typename... > class Action, typename Input, typename... States >
+               static auto apply0( const Input& in, States&&... st ) noexcept( noexcept( apply0_impl< Action >( in, std::make_index_sequence< sizeof...( st ) - 1 >{}, std::forward< States >( st )... ) ) )
+                  -> decltype( auto )
+               {
+                  return apply0_impl< Action >( in, std::make_index_sequence< sizeof...( st ) - 1 >{}, std::forward< States >( st )... );
+               }
+
+               template< template< typename... > class Action, typename Iterator, typename Input, std::size_t... Is, typename... States >
+               static auto apply_impl( const Iterator& begin, const Input& in, std::index_sequence< Is... >, States&&... st ) noexcept( noexcept( Control< Rule >::template apply< Action >( begin, in, std::get< Is >( std::forward_as_tuple ( st... ) )... ) ) )
+                  -> decltype( auto )
+               {
+                  std::get< sizeof...(st) - 1 >( std::forward_as_tuple( st... ) ); // silence C4100
+                  return Control< Rule >::template apply< Action >( begin, in, std::get< Is >( std::forward_as_tuple ( st... ) )... );
+               }
+
+               template< template< typename... > class Action, typename Iterator, typename Input, typename... States >
+               static auto apply( const Iterator& begin, const Input& in, States&&... st ) noexcept( noexcept( apply_impl< Action >( begin, in, std::make_index_sequence< sizeof...( st ) - 1 >{}, std::forward< States >( st )... ) ) )
+                  -> decltype( auto )
+               {
+                  return apply_impl< Action >( begin, in, std::make_index_sequence< sizeof...( st ) - 1 >{}, std::forward< States >( st )... );
+               }
+#else
                template< typename Input, typename... States >
                static void start( const Input& in, States&&... st, state< Node >& /*unused*/ ) noexcept( noexcept( Control< Rule >::start( in, st... ) ) )
                {
@@ -289,6 +375,7 @@ namespace tao
                {
                   return Control< Rule >::template apply< Action >( begin, in, st... );
                }
+#endif
             };
 
             template< typename Node, template< typename... > class Selector, template< typename... > class Control >
@@ -296,6 +383,96 @@ namespace tao
             struct make_control< Node, Selector, Control >::control< Rule, false, false >
                : Control< Rule >
             {
+#if defined(_MSC_VER) && _MSC_VER == 1900
+               template< typename Input, std::size_t... Is, typename... States >
+               static void start_impl( const Input& in, std::index_sequence< Is... >, States&&... st )
+               {
+                  Control< Rule >::start( in, std::get< Is >( std::forward_as_tuple ( st... ) )... );
+                  state< Node >& state = std::get< sizeof...( st ) - 1 >( std::forward_as_tuple( st... ) );
+                  state.emplace_back();
+               }
+
+               template< typename Input, typename... States >
+               static void start( const Input& in, States&&... st ) noexcept( noexcept( start_impl( in, std::make_index_sequence< sizeof...( st ) - 1 >{}, std::forward< States >( st )... ) ) )
+               {
+                  start_impl( in, std::make_index_sequence< sizeof...( st ) - 1 >{}, std::forward< States >( st )... );
+               }
+
+               template< typename Input, std::size_t... Is, typename... States >
+               static void success_impl( const Input& in, std::index_sequence< Is... >, States&&... st )
+               {
+                  Control< Rule >::success( in, std::get< Is >( std::forward_as_tuple ( st... ) )... );
+                  state< Node >& state = std::get< sizeof...( st ) - 1 >( std::forward_as_tuple( st... ) );
+                  auto n = std::move( state.back() );
+                  state.pop_back();
+                  for( auto& c : n->children ) {
+                     state.back()->children.emplace_back( std::move( c ) );
+                  }
+               }
+
+               template< typename Input, typename... States >
+               static void success( const Input& in, States&&... st ) noexcept( noexcept( success_impl( in, std::make_index_sequence< sizeof...( st ) - 1 >{}, std::forward< States >( st )... ) ) )
+               {
+                  success_impl( in, std::make_index_sequence< sizeof...( st ) - 1 >{}, std::forward< States >( st )... );
+               }
+
+               template< typename Input, std::size_t... Is, typename... States >
+               static void failure_impl( const Input& in, std::index_sequence< Is... >, States&&... st )
+               {
+                  Control< Rule >::failure( in, std::get< Is >( std::forward_as_tuple ( st... ) )... );
+                  state< Node >& state = std::get< sizeof...( st ) - 1 >( std::forward_as_tuple( st... ) );
+                  state.pop_back();
+               }
+
+               template< typename Input, typename... States >
+               static void failure( const Input& in, States&&... st ) noexcept( noexcept( failure_impl( in, std::make_index_sequence< sizeof...( st ) - 1 >{}, std::forward< States >( st )... ) ) )
+               {
+                  failure_impl( in, std::make_index_sequence< sizeof...( st ) - 1 >{}, std::forward< States >( st )... );
+               }
+
+               template< typename Input, std::size_t... Is, typename... States >
+               static void raise_impl( const Input& in, std::index_sequence< Is... >, States&&... st )
+               {
+                  std::get< sizeof...(st) - 1 >( std::forward_as_tuple( st... ) ); // silence C4100
+                  Control< Rule >::raise( in, std::get< Is >( std::forward_as_tuple ( st... ) )... );
+               }
+
+               template< typename Input, typename... States >
+               static void raise( const Input& in, States&&... st )
+               {
+                  raise_impl( in, std::make_index_sequence< sizeof...( st ) - 1 >{}, std::forward< States >( st )... );
+               }
+
+               template< template< typename... > class Action, typename Input, std::size_t... Is, typename... States >
+               static auto apply0_impl( const Input& in, std::index_sequence< Is... >, States&&... st ) noexcept( noexcept( Control< Rule >::template apply0< Action >( in, std::get< Is >( std::forward_as_tuple ( st... ) )... ) ) )
+                  -> decltype( auto )
+               {
+                  std::get< sizeof...(st) - 1 >( std::forward_as_tuple( st... ) ); // silence C4100
+                  return Control< Rule >::template apply0< Action >( in, std::get< Is >( std::forward_as_tuple ( st... ) )... );
+               }
+
+               template< template< typename... > class Action, typename Input, typename... States >
+               static auto apply0( const Input& in, States&&... st ) noexcept( noexcept( apply0_impl< Action >( in, std::make_index_sequence< sizeof...( st ) - 1 >{}, std::forward< States >( st )... ) ) )
+                  -> decltype( auto )
+               {
+                  return apply0_impl< Action >( in, std::make_index_sequence< sizeof...( st ) - 1 >{}, std::forward< States >( st )... );
+               }
+
+               template< template< typename... > class Action, typename Iterator, typename Input, std::size_t... Is, typename... States >
+               static auto apply_impl( const Iterator& begin, const Input& in, std::index_sequence< Is... >, States&&... st ) noexcept( noexcept( Control< Rule >::template apply< Action >( begin, in, std::get< Is >( std::forward_as_tuple ( st... ) )... ) ) )
+                  -> decltype( auto )
+               {
+                  std::get< sizeof...(st) - 1 >( std::forward_as_tuple( st... ) ); // silence C4100
+                  return Control< Rule >::template apply< Action >( begin, in, std::get< Is >( std::forward_as_tuple ( st... ) )... );
+               }
+
+               template< template< typename... > class Action, typename Iterator, typename Input, typename... States >
+               static auto apply( const Iterator& begin, const Input& in, States&&... st ) noexcept( noexcept( apply_impl< Action >( begin, in, std::make_index_sequence< sizeof...( st ) - 1 >{}, std::forward< States >( st )... ) ) )
+                  -> decltype( auto )
+               {
+                  return apply_impl< Action >( begin, in, std::make_index_sequence< sizeof...( st ) - 1 >{}, std::forward< States >( st )... );
+               }
+#else
                template< typename Input, typename... States >
                static void start( const Input& in, States&&... st, state< Node >& state )
                {
@@ -340,6 +517,7 @@ namespace tao
                {
                   return Control< Rule >::template apply< Action >( begin, in, st... );
                }
+#endif
             };
 
             template< typename Node, template< typename... > class Selector, template< typename... > class Control >
@@ -347,6 +525,100 @@ namespace tao
             struct make_control< Node, Selector, Control >::control< Rule, true, B >
                : Control< Rule >
             {
+#if defined(_MSC_VER) && _MSC_VER == 1900
+               template< typename Input, std::size_t... Is, typename... States >
+               static void start_impl( const Input& in, std::index_sequence< Is... >, States&&... st )
+               {
+                  Control< Rule >::start( in, std::get< Is >( std::forward_as_tuple ( st... ) )... );
+                  state< Node >& state = std::get< sizeof...( st ) - 1 >( std::forward_as_tuple( st... ) );
+                  state.emplace_back();
+                  state.back()->template start< Rule >( in, std::get< Is >( std::forward_as_tuple ( st... ) )... );
+               }
+
+               template< typename Input, typename... States >
+               static void start( const Input& in, States&&... st ) noexcept( noexcept( start_impl( in, std::make_index_sequence< sizeof...( st ) - 1 >{}, std::forward< States >( st )... ) ) )
+               {
+                  start_impl( in, std::make_index_sequence< sizeof...( st ) - 1 >{}, std::forward< States >( st )... );
+               }
+
+               template< typename Input, std::size_t... Is, typename... States >
+               static void success_impl( const Input& in, std::index_sequence< Is... >, States&&... st )
+               {
+                  Control< Rule >::success( in, std::get< Is >( std::forward_as_tuple ( st... ) )... );
+                  state< Node >& state = std::get< sizeof...( st ) - 1 >( std::forward_as_tuple( st... ) );
+                  auto n = std::move( state.back() );
+                  state.pop_back();
+                  n->template success< Rule >( in, std::get< Is >( std::forward_as_tuple ( st... ) )... );
+                  transform< Selector< Rule > >( n, std::get< Is >( std::forward_as_tuple ( st... ) )... );
+                  if( n ) {
+                     state.back()->emplace_back( std::move( n ), std::get< Is >( std::forward_as_tuple ( st... ) )... );
+                  }
+               }
+
+               template< typename Input, typename... States >
+               static void success( const Input& in, States&&... st ) noexcept( noexcept( success_impl( in, std::make_index_sequence< sizeof...( st ) - 1 >{}, std::forward< States >( st )... ) ) )
+               {
+                  success_impl( in, std::make_index_sequence< sizeof...( st ) - 1 >{}, std::forward< States >( st )... );
+               }
+
+               template< typename Input, std::size_t... Is, typename... States >
+               static void failure_impl( const Input& in, std::index_sequence< Is... >, States&&... st )
+               {
+                  Control< Rule >::failure( in, std::get< Is >( std::forward_as_tuple ( st... ) )... );
+                  state< Node >& state = std::get< sizeof...( st ) - 1 >( std::forward_as_tuple( st... ) );
+                  state.back()->template failure< Rule >( in, std::get< Is >( std::forward_as_tuple ( st... ) )... );
+                  state.pop_back();
+               }
+
+               template< typename Input, typename... States >
+               static void failure( const Input& in, States&&... st ) noexcept( noexcept( failure_impl( in, std::make_index_sequence< sizeof...( st ) - 1 >{}, std::forward< States >( st )... ) ) )
+               {
+                  failure_impl( in, std::make_index_sequence< sizeof...( st ) - 1 >{}, std::forward< States >( st )... );
+               }
+
+               template< typename Input, std::size_t... Is, typename... States >
+               static void raise_impl( const Input& in, std::index_sequence< Is... >, States&&... st ) noexcept( noexcept( Control< Rule >::raise( in, std::get< Is >( std::forward_as_tuple ( st... ) )... ) ) )
+               {
+                  std::get< sizeof...(st) - 1 >( std::forward_as_tuple( st... ) ); // silence C4100
+                  Control< Rule >::raise( in, std::get< Is >( std::forward_as_tuple ( st... ) )... );
+               }
+
+               template< typename Input, typename... States >
+               static void raise( const Input& in, States&&... st ) noexcept( noexcept( raise_impl( in, std::make_index_sequence< sizeof...( st ) - 1 >{}, std::forward< States >( st )... ) ) )
+               {
+                  raise_impl( in, std::make_index_sequence< sizeof...( st ) - 1 >{}, std::forward< States >( st )... );
+               }
+
+               template< template< typename... > class Action, typename Input, std::size_t... Is, typename... States >
+               static auto apply0_impl( const Input& in, std::index_sequence< Is... >, States&&... st ) noexcept( noexcept( Control< Rule >::template apply0< Action >( in, std::get< Is >( std::forward_as_tuple ( st... ) )... ) ) )
+                  -> decltype( auto )
+               {
+                  std::get< sizeof...(st) - 1 >( std::forward_as_tuple( st... ) ); // silence C4100
+                  return Control< Rule >::template apply0< Action >( in, std::get< Is >( std::forward_as_tuple ( st... ) )... );
+               }
+
+               template< template< typename... > class Action, typename Input, typename... States >
+               static auto apply0( const Input& in, States&&... st ) noexcept( noexcept( apply0_impl< Action >( in, std::make_index_sequence< sizeof...( st ) - 1 >{}, std::forward< States >( st )... ) ) )
+                  -> decltype( auto )
+               {
+                  return apply0_impl< Action >( in, std::make_index_sequence< sizeof...( st ) - 1 >{}, std::forward< States >( st )... );
+               }
+
+               template< template< typename... > class Action, typename Iterator, typename Input, std::size_t... Is, typename... States >
+               static auto apply_impl( const Iterator& begin, const Input& in, std::index_sequence< Is... >, States&&... st ) noexcept( noexcept( Control< Rule >::template apply< Action >( begin, in, std::get< Is >( std::forward_as_tuple ( st... ) )... ) ) )
+                  -> decltype( auto )
+               {
+                  std::get< sizeof...(st) - 1 >( std::forward_as_tuple( st... ) ); // silence C4100
+                  return Control< Rule >::template apply< Action >( begin, in, std::get< Is >( std::forward_as_tuple ( st... ) )... );
+               }
+
+               template< template< typename... > class Action, typename Iterator, typename Input, typename... States >
+               static auto apply( const Iterator& begin, const Input& in, States&&... st ) noexcept( noexcept( apply_impl< Action >( begin, in, std::make_index_sequence< sizeof...( st ) - 1 >{}, std::forward< States >( st )... ) ) )
+                  -> decltype( auto )
+               {
+                  return apply_impl< Action >( begin, in, std::make_index_sequence< sizeof...( st ) - 1 >{}, std::forward< States >( st )... );
+               }
+#else
                template< typename Input, typename... States >
                static void start( const Input& in, States&&... st, state< Node >& state )
                {
@@ -395,6 +667,7 @@ namespace tao
                {
                   return Control< Rule >::template apply< Action >( begin, in, st... );
                }
+#endif
             };
 
             template< typename >


### PR DESCRIPTION
This is same as #131 but intended for the 2.7.x branch for C++11 / VS 2015 support. The latest attempt to build on VS 2015 is following your Plan B approach from the discussion in #131.