### PR TITLE
Hierarchical actions [WIP]

### DIFF
--- a/include/tao/pegtl/contrib/hierarchical.hpp
+++ b/include/tao/pegtl/contrib/hierarchical.hpp
@@ -1,0 +1,91 @@
+// Copyright (c) 2019 Dr. Colin Hirsch and Daniel Frey
+// Please see LICENSE for license or visit https://github.com/taocpp/PEGTL/
+
+#ifndef TAO_PEGTL_CONTRIB_HIERARCHICAL_HPP
+#define TAO_PEGTL_CONTRIB_HIERARCHICAL_HPP
+
+#include "../config.hpp"
+#include "../normal.hpp"
+
+#include <type_traits>
+
+namespace tao
+{
+   namespace TAO_PEGTL_NAMESPACE
+   {
+      // Base class to use as tag
+      struct hierarchical_action_tag
+      {};
+
+      namespace internal
+      {
+         // Detect if the class derives from hierarchical action and therefore is a hierarchical action
+         template< typename T >
+         constexpr bool is_hierarchical_action = std::is_base_of_v< hierarchical_action_tag, T >;
+      }  // namespace internal
+
+      // Control class that dispatches on hierarchical action
+      template< class Rule >
+      struct hierarchical_control : normal< Rule >
+      {
+         template< apply_mode A,
+                   rewind_mode M,
+                   template< typename... >
+                   class Action,
+                   template< typename... >
+                   class Control,
+                   typename Input,
+                   typename... States >
+         [[nodiscard]] static bool match( Input& in, States&&... st )
+         {
+            using action_t = Action< Rule >;
+            if constexpr( internal::is_hierarchical_action< action_t > ) {
+               return action_t::template match< A, M, Action, Control >( in, st... );
+            }
+            else {
+               return normal< Rule >::template match< A, M, Action, Control >( in, st... );
+            }
+         }
+      };
+
+      // Change action when starting to match rule
+      template< typename Rule, template< typename... > class NewAction >
+      struct hierarchical_change_action : hierarchical_action_tag
+      {
+         template< apply_mode A,
+                   rewind_mode M,
+                   template< typename... >
+                   class Action,
+                   template< typename... >
+                   class Control,
+                   typename Input,
+                   typename... States >
+         [[nodiscard]] static bool match( Input& in, States&&... st )
+         {
+            return Control< Rule >::template match< A, M, NewAction, Control >( in, st... );
+         }
+      };
+
+      // Change control and use new control to match rule
+      template< typename Rule, template< typename... > class NewControl >
+      struct hierarchical_change_control : hierarchical_action_tag
+      {
+         template< apply_mode A,
+                   rewind_mode M,
+                   template< typename... >
+                   class Action,
+                   template< typename... >
+                   class Control,
+                   typename Input,
+                   typename... States >
+         [[nodiscard]] static bool match( Input& in, States&&... st )
+         {
+            return Control< Rule >::template match< A, M, Action, NewControl >( in, st... );
+         }
+      };
+
+   }  // namespace TAO_PEGTL_NAMESPACE
+
+}  // namespace tao
+
+#endif

--- a/src/test/pegtl/CMakeLists.txt
+++ b/src/test/pegtl/CMakeLists.txt
@@ -18,6 +18,7 @@ set(test_sources
   ascii_three.cpp
   ascii_two.cpp
   contrib_alphabet.cpp
+  contrib_hierarchical.cpp
   contrib_integer.cpp
   contrib_if_then.cpp
   contrib_json.cpp

--- a/src/test/pegtl/contrib_hierarchical.cpp
+++ b/src/test/pegtl/contrib_hierarchical.cpp
@@ -1,0 +1,70 @@
+// Copyright (c) 2019 Dr. Colin Hirsch and Daniel Frey
+// Please see LICENSE for license or visit https://github.com/taocpp/PEGTL/
+
+#include "test.hpp"
+
+#include <tao/pegtl/contrib/hierarchical.hpp>
+
+#include <tao/pegtl/ascii.hpp>
+#include <tao/pegtl/nothing.hpp>
+#include <tao/pegtl/rules.hpp>
+
+namespace tao
+{
+   namespace TAO_PEGTL_NAMESPACE
+   {
+      struct state_one
+      {
+         int byte_in_line_a;
+         int byte_in_line_b;
+      };
+
+      // clang-format off
+      struct grammar_inner : one< 'a' > {};
+      struct grammar_one_b : seq< grammar_inner > {};
+      struct grammar_one_a : seq< grammar_inner, grammar_one_b, eof > {};
+
+      template< typename Rule >
+      struct action_one_b : nothing< Rule > {};
+
+      template< typename Rule >
+      struct action_one_a : nothing< Rule > {};
+      // clang-format on
+
+      template<>
+      struct action_one_b< grammar_inner >
+      {
+         template< typename Input >
+         static void apply( const Input& in, state_one& state )
+         {
+            state.byte_in_line_b = in.input().byte();
+         }
+      };
+
+      template<>
+      struct action_one_a< grammar_one_b > : hierarchical_change_action< grammar_one_b, action_one_b >
+      {};
+
+      template<>
+      struct action_one_a< grammar_inner >
+      {
+         template< typename Input >
+         static void apply( const Input& in, state_one& state )
+         {
+            state.byte_in_line_a = in.input().byte();
+         }
+      };
+
+      void unit_test()
+      {
+         state_one state{ -1, -1 };
+         bool parse_result = parse< grammar_one_a, action_one_a, hierarchical_control >( memory_input( "aa", __FUNCTION__ ), state );
+         TAO_PEGTL_TEST_ASSERT( parse_result );
+         TAO_PEGTL_TEST_ASSERT( state.byte_in_line_a == 1 );
+         TAO_PEGTL_TEST_ASSERT( state.byte_in_line_b == 2 );
+      }
+
+   }  // namespace TAO_PEGTL_NAMESPACE
+}  // namespace tao
+
+#include "main.hpp"


### PR DESCRIPTION
This is the initial hierarchical action prototype. I played around with quite a few different variants of this. This is, in my opinion, a flexible and simple approach. 

Any action can be made hierarchical by inheriting from the `hierarchical_action_tag`. The hierarchical action is then responsible for calling the `match` function with the correct arguments.

Example: An action that changes the action of a nested rule

```c++
// Change action when starting to match rule
template< typename Rule, template< typename... > class NewAction >
struct hierarchical_change_action : hierarchical_action_tag
{
   template< apply_mode A,
             rewind_mode M,
             template< typename... >
             class Action,
             template< typename... >
             class Control,
             typename Input,
             typename... States >
   [[nodiscard]] static bool match( Input& in, States&&... st )
   {
      return Control< Rule >::template match< A, M, NewAction, Control >( in, st... );
   }
};
```

Benefits

- Allows putting state on the stack without swindling the control class and/or managing the "parse stack" by hand.
- Allows much better composability.
- Hierarchical actions match how hand-written recursive descent parsers work more closely.
- Is implemented as a new control, so it's opt-in only but won't affect anyone if it's in all controls.

Build failure:

- Coverage fails since I have an `hierarchical_change_control` that is currently untested. I'm waiting to finalise the implementation then I'll complete the testing.
- Clang-tidy failure since it doesn't like my `if constexpr {} else {}` due to it's `readability-else-after-return` rule. I'll add `NOLINT` later.

Possible changes:

- The syntax of declaring a hierarchical action

  - Currently, inherit from a tag

    ```c++
    struct my_rule : hierarchical_tag {
    	// Rule body
    }
    
    template <typename T>
    constexpr bool is_hierarchical_action = std::is_base_of_v< hierarchical_action_tag, T>;
    ```

  - Can also be made into a template that inherits from `std::false` by default and gets specialised to `std::true` if it's a hierarchical action. This matches the general style of `PEGTL` more, but it feels like more boilerplate.

    ```c++
    template <typename Rule>
    struct is_hierarchial_action : std::false {};
    
    template <>
    struct is_hierarchical_action <my_rule> : std::true {};
    ```

  - Can have a type tag and use SFINAE. A bit ugly, but still an option.

    ```c++
    struct my_rule {
        struct hierarchical_tag {};
        
        // Rule body
    }
    
    template <typename Rule>
    struct is_hierarchial_action; // Some SFINAE that detects Rule::hierarchical_tag
    ```

- The syntax of hierarchical_action body

  - Use the same signature as a complex rule (as in the example). 

  - Use a functor

    ```c++
    template< apply_mode A,
              rewind_mode M,
              template< typename... >
              class Action,
              template< typename... >
              class Control>
    struct functor {
       static constexpr apply_mode a;
       static constexpr rewind_mode m;
       
       template <typename... Rules>
       using action_t = Action<Rules...>;
       
       template <typename... Rules>
       using control_t = Control<Rules...>;
       
       template<typename Rule, typename Input, typename... States>
       [[nodiscard]] bool match(Input& input, States&&... states) {
          return control_t< Rule >::template match< a, m, action_t, control_t >( in, st... );
       }
    };
    
    template <typename Functor>
    auto change_function_action(FunctorFrom functor);
    
    template<typename Rule, typename template<typename...> NewAction>
    struct hierarchical_change_action : hierarchical_action_tag {
        template <typename Functor,
                  typename Input,
                  typename... States>
        [[nodiscard]] bool match(Function functor, Input& input, States&&... states)
        {
           auto new_functor = change_function_action<NewAction>(functor);
           return new_functor<Rule>(input, states...);
        }
    };
    ```

    This is very clean but doesn't match the PEGTL style at all. The benefit of the `Functor` style that it is as simple as the simple rule, but doesn't compromise flexibility.

    Can also move `Input`,`States...`, and `Rule`, or a combination thereof into the functor or move some of the functor state out of it.

    NOTE: Didn't test if it compiles
- Implement it as part of `normal` instead of a separate `control`. This will simply reduce template instantiating noise when a compile error happens.