### PR TITLE
Make includable as a uniform CMake dependency

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,6 +2,24 @@ cmake_minimum_required(VERSION 3.8.0 FATAL_ERROR)
 
 project(pegtl VERSION 3.0.0 LANGUAGES CXX)
 
+# Dont re-include pegtl
+if(${PROJECT_NAME}_FOUND)
+  if(NOT ${PROJECT_NAME}_VERSION STREQUAL ${PROJECT_VERSION})
+    message(FATAL_ERROR "Multiple mismatched PEGTL versions")
+  endif()
+
+  return()
+endif()
+
+# Keep track of pegtl version
+set(${PROJECT_NAME}_FOUND TRUE CACHE BOOL "" FORCE)
+set(${PROJECT_NAME}_VERSION ${PROJECT_VERSION} CACHE STRING "" FORCE)
+set(${PROJECT_NAME}_DIR ${PROJECT_BINARY_DIR} CACHE PATH "" FORCE)
+
+mark_as_advanced(${PROJECT_NAME}_FOUND)
+mark_as_advanced(${PROJECT_NAME}_VERSION)
+mark_as_advanced(${PROJECT_NAME}_DIR)
+
 # installation directories
 set(PEGTL_INSTALL_INCLUDE_DIR "include" CACHE STRING "The installation include directory")
 set(PEGTL_INSTALL_DOC_DIR "share/doc/tao/pegtl" CACHE STRING "The installation doc directory")
@@ -30,6 +48,9 @@ option(PEGTL_BUILD_EXAMPLES "Build example programs" ON)
 if(PEGTL_BUILD_EXAMPLES)
   add_subdirectory(src/example/pegtl)
 endif()
+
+# Make package findable
+configure_file(cmake/dummy-config.cmake.in pegtl-config.cmake @ONLY)
 
 # install and export target
 install(TARGETS pegtl EXPORT pegtl-targets)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,19 +2,22 @@ cmake_minimum_required(VERSION 3.8.0 FATAL_ERROR)
 
 project(pegtl VERSION 3.0.0 LANGUAGES CXX)
 
-# Dont re-include pegtl
 if(${PROJECT_NAME}_FOUND)
+  # Multiple versions of PEGTL can't co-exist
   if(NOT ${PROJECT_NAME}_VERSION STREQUAL ${PROJECT_VERSION})
     message(FATAL_ERROR "Multiple mismatched PEGTL versions")
   endif()
 
-  return()
+  # Only include if this is the first include
+  if(NOT ${PROJECT_NAME}_DIR STREQUAL "${PROJECT_BINARY_DIR}")
+    return()
+  endif()
 endif()
 
 # Keep track of pegtl version
 set(${PROJECT_NAME}_FOUND TRUE CACHE BOOL "" FORCE)
-set(${PROJECT_NAME}_VERSION ${PROJECT_VERSION} CACHE STRING "" FORCE)
-set(${PROJECT_NAME}_DIR ${PROJECT_BINARY_DIR} CACHE PATH "" FORCE)
+set(${PROJECT_NAME}_VERSION "${PROJECT_VERSION}" CACHE STRING "" FORCE)
+set(${PROJECT_NAME}_DIR "${PROJECT_BINARY_DIR}" CACHE PATH "" FORCE)
 
 mark_as_advanced(${PROJECT_NAME}_FOUND)
 mark_as_advanced(${PROJECT_NAME}_VERSION)

--- a/cmake/dummy-config.cmake.in
+++ b/cmake/dummy-config.cmake.in
@@ -1,14 +1,5 @@
 # Dummy config file
 # When a dependency is added with add_subdirectory, but searched with find_package
 
-# Project must already be found
-if (NOT @PROJECT_NAME@_FOUND)
-  message(FATAL_ERROR "Dummy config, but @PROJECT_NAME@ is not found")
-endif()
-
-if(NOT @PROJECT_NAME@_VERSION STREQUAL "@PROJECT_VERSION@")
-  # Alreadt included project version must match
-  message(FATAL_ERROR "Multiple find/add multiple versions of @PROJECT_NAME@")
-endif()
-
-# Dependency succesfully already included
+# Redirect to the directory added with add_subdirectory
+add_subdirectory(@PROJECT_SOURCE_DIR@ @PROJECT_BINARY_DIR@)

--- a/cmake/dummy-config.cmake.in
+++ b/cmake/dummy-config.cmake.in
@@ -1,0 +1,14 @@
+# Dummy config file
+# When a dependency is added with add_subdirectory, but searched with find_package
+
+# Project must already be found
+if (NOT @PROJECT_NAME@_FOUND)
+  message(FATAL_ERROR "Dummy config, but @PROJECT_NAME@ is not found")
+endif()
+
+if(NOT @PROJECT_NAME@_VERSION STREQUAL "@PROJECT_VERSION@")
+  # Alreadt included project version must match
+  message(FATAL_ERROR "Multiple find/add multiple versions of @PROJECT_NAME@")
+endif()
+
+# Dependency succesfully already included

--- a/conanfile.py
+++ b/conanfile.py
@@ -11,7 +11,7 @@ class PEGTLConan(ConanFile):
     license = "MIT"
     author = "taocpp@icemx.net"
     exports = "LICENSE"
-    exports_sources = "include/*", "CMakeLists.txt"
+    exports_sources = "cmake/*", "include/*", "CMakeLists.txt"
     settings = "build_type", "compiler", "os", "arch"
     generators = "cmake"
     no_copy_source = True

--- a/doc/Installing-and-Using.md
+++ b/doc/Installing-and-Using.md
@@ -45,7 +45,9 @@ Installation packages are available from several package managers. Note that som
 * [Conan]
 * [Spack]
 
-## CMake Installation
+## CMake
+
+### CMake install (Recommended)
 
 The PEGTL can be built and installed using [CMake], e.g.
 
@@ -57,14 +59,68 @@ $ make
 $ make install
 ```
 
-The above will install the PEGTL into the standard installation path on a
-UNIX system, e.g. `/usr/local/include/`. To change the installation path, use:
+The above will install the PEGTL into the standard installation path on a UNIX
+system, e.g. `/usr/local/include/`. To change the installation path, use:
 
 ```sh
 $ cmake .. -DCMAKE_INSTALL_PREFIX=../install
 ```
 
-in the above. For more options and ways to use CMake, please refer to the [CMake documentation].
+in the above. Installation creates a `pegtl-config.cmake` which allows CMake
+project to find PEGTL using `find_package`:
+
+```cmake
+find_package(pegtl)
+```
+
+This exports the `taocpp::pegtl` target which can be linked against any other
+target. Linking against `taocpp:pegtl` automatically set the include
+directories and required flags for C++17 or later. For example:
+
+```cmake
+add_executable(myexe mysources...)
+target_link_libraries(myexe PRIVATE taocpp::pegtl)
+```
+
+### CMake add_subdirectory
+
+The PEGTL can also be added as a dependency with `add_subdirectory`.
+
+```cmake
+add_subdirectory(path/to/PEGTL)
+```
+
+This also exports the `taocpp::pegtl` target which can be linked against any
+other target just as with the installation case. Due to the global nature of
+CMake targets the target `pegtl` is also defined, but only `taocpp::pegtl`
+should be used for consistency. If `PEGTL_BUILD_TESTS` is true then the test
+targets, `pegtl-test-*`, are also defined and their corresponding tests
+registered with `add_test`. If `PEGTL_BUILD_EXAMPLES` is true then the example
+targets, `pegtl-example-*`, are also defined.
+
+### CMake mixing add_subdirectory and find_package
+
+With the advent of improved methods of managing dependencies (such as [Conan],
+[Spack], [CMake FetchContent]), multiple package inclusion methods needs to be
+able to co-exist.
+
+If PEGTL was first included with `find_package` then subsequent calls to
+`add_subdirectory(path/to/PEGTL)` will skip over the body of the
+`CMakeLists.txt` and use the installed package if the version matches. If the
+version does not match a fatal cmake error will be signalled.
+
+If PEGTL was first included with `add_subdirectory` then a dummy
+`pegtl-config.cmake` is created and `pegtl_DIR` is set. Subsequent calls to
+`find_package(pegtl)` will then use the already added package if the version
+matches. If the version does not match a fatal cmake error will be signalled.
+
+Since CMake targets are global, there exists no way for a CMake project to use
+2 different versions of PEGTL simultaneously and signalling a fatal error
+becomes the only practical way of handling the inclusion of multiple different
+PEGTL versions.
+
+For more options and ways to use CMake, please refer to the
+[CMake documentation].
 
 ## Manual Installation
 
@@ -169,5 +225,6 @@ Copyright (c) 2014-2019 Dr. Colin Hirsch and Daniel Frey
 
 [CMake]: https://cmake.org/
 [CMake documentation]: https://cmake.org/documentation/
+[CMake FetchContent]: https://cmake.org/cmake/help/latest/module/FetchContent.html
 [Conan]: https://bintray.com/taocpp/public-conan/pegtl%3Ataocpp
 [Spack]: http://spack.readthedocs.io/en/latest/package_list.html#pegtl


### PR DESCRIPTION
This makes the way PEGTL is included in the project transparent to the
consuming project. If PEGTL is included with `add_subdirectory`
subsequent calls to `find_package` will find the PEGTL version included
with `add_subdirectory`. If PEGTL is included with `find_package`
subsequent calls to `add_subdirectory` will use the PEGTL version
included with find_package.

Since CMake targets are global there exists no way for multiple versions
of PEGTL to exist within one CMake build. Therefore, a FATAL_ERROR is
signalled if an attempt is made to include multiple different versions
of PEGTL.