### PR TITLE
fix: Don't assume test executable position

### DIFF
--- a/src/test/pegtl/CMakeLists.txt
+++ b/src/test/pegtl/CMakeLists.txt
@@ -120,7 +120,7 @@ foreach(testsourcefile ${test_sources})
   if(ANDROID)
     add_test(NAME ${exename} WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/../../.. COMMAND ${CMAKE_COMMAND} -DANDROID_NDK=${ANDROID_NDK} "-DTEST_RESOURCES=src/test/pegtl/data;src/test/pegtl/file_data.txt;Makefile" -DTEST_RESOURCES_DIR=${CMAKE_CURRENT_SOURCE_DIR}/../../.. -DUNITTEST=${CMAKE_CURRENT_BINARY_DIR}/${exename} -DTEST_PARAMETER=-all -P ${CMAKE_CURRENT_SOURCE_DIR}/ExecuteOnAndroid.cmake)
   else()
-    add_test(NAME ${exename} WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/../../.. COMMAND ${CMAKE_CURRENT_BINARY_DIR}/${exename})
+    add_test(NAME ${exename} WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/../../.. COMMAND ${exename})
   endif()
 endforeach(testsourcefile)
 


### PR DESCRIPTION
CMake automatically handles executable targets. The location of the
test targets might be changed by die project including PEGTL with
add_subdirectory.