### PR TITLE
Enable version checks in find_package

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 *~
 build
 private
+/.vs

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -55,6 +55,10 @@ endif()
 # Make package findable
 configure_file(cmake/dummy-config.cmake.in pegtl-config.cmake @ONLY)
 
+# Enable version checks in find_package
+include(CMakePackageConfigHelpers)
+write_basic_package_version_file(pegtl-config-version.cmake COMPATIBILITY SameMajorVersion)
+
 # install and export target
 install(TARGETS pegtl EXPORT pegtl-targets)
 
@@ -64,5 +68,6 @@ install(EXPORT pegtl-targets
   DESTINATION ${PEGTL_INSTALL_CMAKE_DIR}
 )
 
+install(FILES ${CMAKE_CURRENT_BINARY_DIR}/pegtl-config-version.cmake DESTINATION ${PEGTL_INSTALL_CMAKE_DIR})
 install(DIRECTORY include/ DESTINATION ${PEGTL_INSTALL_INCLUDE_DIR})
 install(FILES LICENSE DESTINATION ${PEGTL_INSTALL_DOC_DIR})

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -55,6 +55,9 @@ endif()
 # Make package findable
 configure_file(cmake/dummy-config.cmake.in pegtl-config.cmake @ONLY)
 
+# Ignore pointer width differences since this is a header-only library
+unset(CMAKE_SIZEOF_VOID_P)
+
 # Enable version checks in find_package
 include(CMakePackageConfigHelpers)
 write_basic_package_version_file(pegtl-config-version.cmake COMPATIBILITY SameMajorVersion)


### PR DESCRIPTION
This makes it possible to conditionally add PEGTL as a submodule or use the installed version if it's already a major version match (and greater than or equal to the minor.patch version), e.g.:

```cmake
find_package(pegtl 3.0.0 QUIET CONFIG)
if(NOT pegtl_FOUND)
  # If a compatible version of PEGTL is not already installed, build and install it from the submodule directory.
  set(PEGTL_BUILD_TESTS OFF CACHE BOOL "Disable PEGTL tests")
  set(PEGTL_BUILD_EXAMPLES OFF CACHE BOOL "Disable PEGTL examples")
  set(PEGTL_INSTALL_INCLUDE_DIR ${GRAPHQL_INSTALL_INCLUDE_DIR} CACHE STRING "Override PEGTL include install directory")
  set(PEGTL_INSTALL_CMAKE_DIR ${GRAPHQL_INSTALL_CMAKE_DIR}/pegtl CACHE STRING "Override PEGTL cmake install directory")
  add_subdirectory(PEGTL)
endif()
```