### PR TITLE
Read project version from version.hpp

### DIFF
--- a/.conan/build.py
+++ b/.conan/build.py
@@ -52,7 +52,7 @@ class BuilderSettings(object):
 
     @property
     def reference(self):
-        """ Read project version from CMake file to create Conan referece
+        """ Read project version from version.hpp file to create Conan referece
         """
         pattern = re.compile(r"#define TAO_PEGTL_VERSION \"(\d+\.\d+\.\d+)\"")
         version = None
@@ -62,7 +62,7 @@ class BuilderSettings(object):
                 if result:
                     version = result.group(1)
         if not version:
-            raise Exception("Could not find version in CMakeLists.txt")
+            raise Exception("Could not find version in version.hpp")
         return os.getenv("CONAN_REFERENCE", "pegtl/{}@taocpp/stable".format(version))
 
 if __name__ == "__main__":

--- a/.conan/build.py
+++ b/.conan/build.py
@@ -54,9 +54,9 @@ class BuilderSettings(object):
     def reference(self):
         """ Read project version from CMake file to create Conan referece
         """
-        pattern = re.compile(r"project\(pegtl VERSION (\d+\.\d+\.\d+) LANGUAGES CXX\)")
+        pattern = re.compile(r"#define TAO_PEGTL_VERSION \"(\d+\.\d+\.\d+)\"")
         version = None
-        with open('CMakeLists.txt') as file:
+        with open('include/tao/pegtl/version.hpp') as file:
             for line in file:
                 result = pattern.match(line)
                 if result:

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,11 @@
 cmake_minimum_required(VERSION 3.8.0 FATAL_ERROR)
 
-project(pegtl VERSION 3.0.0 LANGUAGES CXX)
+# Read version from version.hpp
+file(READ "${CMAKE_CURRENT_LIST_DIR}/include/tao/pegtl/version.hpp" version_hpp_data)
+string(REGEX MATCH "#define TAO_PEGTL_VERSION \"([^\"]+)\"" _ ${version_hpp_data})
+set(PEGTL_VERSION "${CMAKE_MATCH_1}")
+
+project(pegtl VERSION ${PEGTL_VERSION} LANGUAGES CXX)
 
 if(${PROJECT_NAME}_FOUND)
   # Multiple versions of PEGTL can't co-exist


### PR DESCRIPTION
Modifies CMakeLists.txt to determine the version from the `version.hpp` file to avoid duplication.

Some relevant discussion in #166 