### PR TITLE
support demangling on known compilers without rtti

### DIFF
--- a/include/tao/pegtl/internal/demangle.hpp
+++ b/include/tao/pegtl/internal/demangle.hpp
@@ -9,11 +9,34 @@
 
 #include "../config.hpp"
 
+#if defined( __clang__ )
+#if __has_feature( cxx_rtti )
+#define TAO_PEGTL_RTTI_ENABLED
+#endif
+#elif defined( __GNUC__ )
+#if defined( __GXX_RTTI )
+#define TAO_PEGTL_RTTI_ENABLED
+#endif
+#elif defined( _MSC_VER )
+#if defined( _CPPRTTI )
+#define TAO_PEGTL_RTTI_ENABLED
+#endif
+#else
+#define TAO_PEGTL_RTTI_ENABLED
+#endif
+
+#if !defined( TAO_PEGTL_RTTI_ENABLED )
+#include <cassert>
+#include <cstring>
+#endif
+
+#if defined( TAO_PEGTL_RTTI_ENABLED )
 #if defined( __GLIBCXX__ )
 #define TAO_PEGTL_USE_CXXABI_DEMANGLE
 #elif defined( __has_include )
 #if __has_include( <cxxabi.h> )
 #define TAO_PEGTL_USE_CXXABI_DEMANGLE
+#endif
 #endif
 #endif
 
@@ -33,7 +56,24 @@ namespace tao
          template< typename T >
          std::string demangle()
          {
+#if defined( TAO_PEGTL_RTTI_ENABLED )
             return demangle( typeid( T ).name() );
+#else
+            const char* start = nullptr;
+            const char* stop = nullptr;
+#if defined( __clang__ ) || defined( __GNUC__ )
+            start = std::strchr( __PRETTY_FUNCTION__, '=' ) + 2;
+            stop = std::strrchr( start, ';' );
+#elif defined( _MSC_VER )
+            start = std::strstr( __FUNCSIG__, "demangle<" ) + ( sizeof( "demangle<" ) - 1 );
+            stop = std::strrchr( start, '>' );
+#else
+            static_assert( false, "expected to use rtti with this compiler" );
+#endif
+            assert( start != nullptr );
+            assert( stop != nullptr );
+            return { start, std::size_t( stop - start ) };
+#endif
          }
 
       }  // namespace internal


### PR DESCRIPTION
This more properly addresses the question posed in #146.

Unfortunately, even pulling in the demangle header prevents compilation with gcc when rtti is disabled (msvc is more forgiving about this). This makes PEGTL pretty much unusable when working in an environment without rtti. This patch just adds the demangling functionality needed without relying on rtti using compiler specific functionality for gcc, clang, and msvc.

Note, this patch is against the 2.x branch.