### PR TITLE
add missing virtual dtors

### DIFF
--- a/src/example/pegtl/json_classes.hpp
+++ b/src/example/pegtl/json_classes.hpp
@@ -62,6 +62,7 @@ namespace examples
          : json_base( json_type::array )
       {
       }
+      virtual ~array_json() = default;
 
       std::vector< std::shared_ptr< json_base > > data;
 
@@ -87,6 +88,7 @@ namespace examples
            data( in_data )
       {
       }
+      virtual ~boolean_json() = default;
 
       bool data;
 
@@ -103,6 +105,7 @@ namespace examples
          : json_base( json_type::null )
       {
       }
+      virtual ~null_json() = default;
 
       void stream( std::ostream& o ) const override
       {
@@ -118,6 +121,7 @@ namespace examples
            data( in_data )
       {
       }
+      virtual ~number_json() = default;
 
       long double data;
 
@@ -183,6 +187,7 @@ namespace examples
            data( in_data )
       {
       }
+      virtual ~string_json() = default;
 
       std::string data;
 
@@ -199,6 +204,7 @@ namespace examples
          : json_base( json_type::object )
       {
       }
+      virtual ~object_json() = default;
 
       std::map< std::string, std::shared_ptr< json_base > > data;
 


### PR DESCRIPTION
Fixes clang warnings
/usr/include/c++/v1/memory:3710:5: error: destructor called on non-final 'examples::null_json' that has virtual functions but non-virtual destructor [-Werror,-Wdelete-non-abstract-non-virtual-dtor]
__data_.second().~_Tp();
^

Signed-off-by: Khem Raj <raj.khem@gmail.com>