### PR TITLE
Allow printing graphs of subsets of the whole parse tree.

### DIFF
--- a/include/tao/pegtl/contrib/parse_tree_to_dot.hpp
+++ b/include/tao/pegtl/contrib/parse_tree_to_dot.hpp
@@ -92,9 +92,8 @@ namespace TAO_PEGTL_NAMESPACE::parse_tree
 
    void print_dot( std::ostream& os, const parse_tree::node& n )
    {
-      assert( n.is_root() );
       os << "digraph parse_tree\n{\n";
-      internal::print_dot_node( os, n, "ROOT" );
+      internal::print_dot_node( os, n, n.is_root() ? "ROOT": n.type );
       os << "}\n";
    }
 


### PR DESCRIPTION
Also allows, e.g. parse_tree::fold_one::transform(root)