### PR TITLE
Fix Cygwin build

### DIFF
--- a/include/tao/pegtl/internal/endian.hpp
+++ b/include/tao/pegtl/internal/endian.hpp
@@ -9,7 +9,7 @@
 
 #include "../config.hpp"
 
-#if defined( _WIN32 ) && !defined( __MINGW32__ )
+#if defined( _WIN32 ) && !defined( __MINGW32__ ) && !defined( __CYGWIN__ )
 #include "endian_win.hpp"
 #else
 #include "endian_gcc.hpp"


### PR DESCRIPTION
The functions `_byteswap_ushort()` etc. are not directly available on Cygwin (and MSYS2) because even though it defines `_WIN32` it does not expose MSVC intrinsics by default.

The choice here is to either fall back to GCC builtins, or include `w32api/intrin.h`. The former seemed safer and less intrusive to me.