### PR TITLE
Remove unused variable

### DIFF
--- a/src/example/pegtl/dynamic_match.cpp
+++ b/src/example/pegtl/dynamic_match.cpp
@@ -96,9 +96,6 @@ namespace TAO_PEGTL_NAMESPACE
 
 int main( int argc, char** argv )  // NOLINT(bugprone-exception-escape)
 {
-   const auto issues = pegtl::analyze< dynamic::grammar >();
-   assert( !issues );
-
    if( argc > 1 ) {
       std::string id;
       std::string body;


### PR DESCRIPTION
GCC 10.1.0 compilation error: `dynamic_match.cpp:99:15: error: unused variable ‘issues’ [-Werror=unused-variable]`