### PR TITLE
Updated contrib/json so that it is not greedy.

### DIFF
--- a/include/tao/pegtl/contrib/json.hpp
+++ b/include/tao/pegtl/contrib/json.hpp
@@ -58,8 +58,8 @@ namespace TAO_PEGTL_NAMESPACE::json
    struct value;
 
    struct array_element;
-   struct array_content : opt< list_must< array_element, value_separator > > {};
-   struct array : seq< begin_array, array_content, must< end_array > >
+   struct array_content : opt< list_must< array_element, value_separator, ws > > {};
+   struct array : seq< begin_array, pad< array_content, ws >, must< end_array > >
    {
       using begin = begin_array;
       using end = end_array;
@@ -67,9 +67,9 @@ namespace TAO_PEGTL_NAMESPACE::json
       using content = array_content;
    };
 
-   struct member : if_must< key, name_separator, value > {};
-   struct object_content : opt< list_must< member, value_separator > > {};
-   struct object : seq< begin_object, object_content, must< end_object > >
+   struct member : if_must< key, name_separator, pad< value, ws > > {};
+   struct object_content : opt< list_must< member, value_separator, ws > > {};
+   struct object : seq< begin_object, pad< object_content, ws>, must< end_object > >
    {
       using begin = begin_object;
       using end = end_object;
@@ -77,7 +77,7 @@ namespace TAO_PEGTL_NAMESPACE::json
       using content = object_content;
    };
 
-   struct value : padr< sor< string, number, object, array, false_, true_, null > > {};
+   struct value : sor< string, number, object, array, false_, true_, null > {};
    struct array_element : seq< value > {};
 
    struct text : seq< star< ws >, value > {};

--- a/src/test/pegtl/contrib_json.cpp
+++ b/src/test/pegtl/contrib_json.cpp
@@ -22,7 +22,8 @@ namespace TAO_PEGTL_NAMESPACE
       }
    }
 
-   using GRAMMAR = must< json::text, eof >;
+   using GRAMMAR = must< json::text, opt< star< json::ws > >, eof >;
+   using GRAMMAR2 = must< json::text >;
 
    void unit_test()
    {
@@ -54,6 +55,11 @@ namespace TAO_PEGTL_NAMESPACE
       verify_rule< GRAMMAR >( __LINE__, __FILE__, "[\"\xC3\x84\"]", result_type::success, 0 );          // German a-umlaut
       verify_rule< GRAMMAR >( __LINE__, __FILE__, "[\"\xF4\x8F\xBF\xBF\"]", result_type::success, 0 );  // largest allowed codepoint U+10FFFF
       verify_rule< GRAMMAR >( __LINE__, __FILE__, "[\"\U0010FFFF\"]", result_type::success, 0 );        // largest allowed codepoint U+10FFFF
+
+      // should not consume tokens after the json
+      verify_rule< GRAMMAR2 >( __LINE__, __FILE__, "  []  ", result_type::success, 2 );
+      verify_rule< GRAMMAR2 >( __LINE__, __FILE__, "  {}  ", result_type::success, 2 );
+      verify_rule< GRAMMAR2 >( __LINE__, __FILE__, "  5  ", result_type::success, 2 );
 
       verify_fail< GRAMMAR >( __LINE__, __FILE__, "" );
       verify_fail< GRAMMAR >( __LINE__, __FILE__, " " );


### PR DESCRIPTION
contrib/json no longer consumes the whitespace after the json value.