### PR TITLE
Add a CMake option to force building with Boost.Filesystem

### DIFF
--- a/.github/workflows/main-ci.yml
+++ b/.github/workflows/main-ci.yml
@@ -48,7 +48,7 @@ jobs:
       run: cmake --build . --config ${{matrix.build_type}}
 
     - name: Test
-      if: ${{!contains(matrix.image, "arm7")}}
+      if: ${{!contains(matrix.image, 'arm7')}}
       working-directory: build/
       run: ctest -C ${{matrix.build_type}} --output-on-failure
 

--- a/.github/workflows/main-ci.yml
+++ b/.github/workflows/main-ci.yml
@@ -48,7 +48,7 @@ jobs:
       run: cmake --build . --config ${{matrix.build_type}}
 
     - name: Test
-      if: ${{!contains(matrix.image, 'arm7')}}
+      if: ${{!contains(matrix.image, 'armv7')}}
       working-directory: build/
       run: ctest -C ${{matrix.build_type}} --output-on-failure
 

--- a/.github/workflows/main-ci.yml
+++ b/.github/workflows/main-ci.yml
@@ -48,6 +48,7 @@ jobs:
       run: cmake --build . --config ${{matrix.build_type}}
 
     - name: Test
+      if: ${{!contains(matrix.image, "arm7")}}
       working-directory: build/
       run: ctest -C ${{matrix.build_type}} --output-on-failure
 

--- a/.github/workflows/std-filesystem-fallbacks.yml
+++ b/.github/workflows/std-filesystem-fallbacks.yml
@@ -37,27 +37,8 @@ jobs:
     steps:
       - uses: actions/checkout@v2
 
-      - name: Cache Boost
-        uses: actions/cache@v2.1.3
-        id: cache-boost-filesystem
-        with:
-          path: "${{ runner.workspace }}/boost"
-          key: boost-filesystem-${{ matrix.os }}
-
       - name: Install Boost
-        shell: bash
-        env:
-          CACHE_HIT: ${{steps.cache-boost-filesystem.outputs.cache-hit}}
-        run: |
-          if [[ "$CACHE_HIT" == 'true' ]]; then
-            sudo cp --force --recursive ${{ runner.workspace }}/boost/* /
-          else
-            sudo apt-get update && sudo apt-get install -yq libboost-filesystem-dev
-            mkdir -p ${{runner.workspace}}/boost
-            for dep in libboost-filesystem-dev; do
-              dpkg -L $dep | while IFS= read -r f; do if test -f $f; then echo $f; fi; done | xargs cp --parents --target-directory ${{runner.workspace}}/boost/
-            done
-          fi
+        run: sudo apt-get update && sudo apt-get install -yq libboost-filesystem-dev
 
       - name: Create Build Environment
         # Some projects don't allow in-source building, so create a separate build directory

--- a/.github/workflows/std-filesystem-fallbacks.yml
+++ b/.github/workflows/std-filesystem-fallbacks.yml
@@ -69,7 +69,7 @@ jobs:
         # Note the current convention is to use the -S and -B options here to specify source
         # and build directories, but this is only available with CMake 3.13 and higher.
         # The CMake binaries on the Github Actions machines are (as of this writing) 3.12
-        run: cmake -DPEGTL_USE_BOOST_FILESYSTEM=ON -DCMAKE_BUILD_TYPE=${{ matrix.config }} -G Ninja "$GITHUB_WORKSPACE"
+        run: cmake -DPEGTL_USE_BOOST_FILESYSTEM=ON -DCMAKE_BUILD_TYPE=${{ matrix.config }} "$GITHUB_WORKSPACE"
         env:
           CC: ${{ matrix.cc }}
           CXX: ${{ matrix.cxx }}

--- a/.github/workflows/std-filesystem-fallbacks.yml
+++ b/.github/workflows/std-filesystem-fallbacks.yml
@@ -1,7 +1,7 @@
-# Even when building with C++17 support, std::filesystem was not initially implemented
-# in several common tool-chains, or it required additional build logic to enable it.
-# This GitHub Action is supposed to test whether or not the fallback/configuration logic
-# for that works in PEGTL.
+# Test with the PEGTL_USE_BOOST_FILESYSTEM option which forces the build to use
+# the Boost.Filesystem alternative to std::filesystem. This option is there so
+# that consumers who are still building with Boost.Filesystem can work with
+# PEGTL, although they still need support for the rest of the C++17 standard.
 name: std-filesystem-fallbacks
 
 on:
@@ -14,15 +14,17 @@ on:
 
 jobs:
   ubuntu-gcc:
-    name: ${{ matrix.os }} with ${{ matrix.cc }}
+    name: ${{ matrix.os }} with ${{ matrix.cc }} (${{ matrix.config }})
     runs-on: ${{ matrix.os }}
     strategy:
       # Run all of them once we start
       fail-fast: false
       matrix:
         os:
-          - ubuntu-16.04
-          - ubuntu-18.04
+          - ubuntu-latest
+        config:
+          - Debug
+          - Release
         cc:
           - gcc-7
           - gcc-8
@@ -39,7 +41,7 @@ jobs:
         uses: actions/cache@v2.1.3
         id: cache-boost-filesystem
         with:
-          path: "${{runner.workspace}}/boost"
+          path: "${{ runner.workspace }}/boost"
           key: boost-filesystem-${{ matrix.os }}
 
       - name: Install Boost
@@ -48,7 +50,7 @@ jobs:
           CACHE_HIT: ${{steps.cache-boost-filesystem.outputs.cache-hit}}
         run: |
           if [[ "$CACHE_HIT" == 'true' ]]; then
-            sudo cp --force --recursive ${{runner.workspace}}/boost/* /
+            sudo cp --force --recursive ${{ runner.workspace }}/boost/* /
           else
             sudo apt-get update && sudo apt-get install -yq libboost-filesystem-dev
             mkdir -p ${{runner.workspace}}/boost
@@ -60,30 +62,25 @@ jobs:
       - name: Create Build Environment
         # Some projects don't allow in-source building, so create a separate build directory
         # We'll use this as our working directory for all subsequent commands
-        run: cmake -E make_directory ${{runner.workspace}}/build
+        run: cmake -E make_directory ${{ runner.workspace }}/build
 
       - name: Configure CMake
-        shell: bash
-        working-directory: ${{runner.workspace}}/build
+        working-directory: ${{ runner.workspace }}/build
         # Note the current convention is to use the -S and -B options here to specify source
         # and build directories, but this is only available with CMake 3.13 and higher.
         # The CMake binaries on the Github Actions machines are (as of this writing) 3.12
-        run: cmake "$GITHUB_WORKSPACE"
+        run: cmake -DPEGTL_USE_BOOST_FILESYSTEM=ON -DCMAKE_BUILD_TYPE=${{ matrix.config }} -G Ninja "$GITHUB_WORKSPACE"
         env:
-          CC: ${{matrix.cc}}
-          CXX: ${{matrix.cxx}}
+          CC: ${{ matrix.cc }}
+          CXX: ${{ matrix.cxx }}
 
       - name: Build the Project
-        shell: bash
-        working-directory: ${{runner.workspace}}/build
+        working-directory: ${{ runner.workspace }}/build
         # Execute the build.  You can specify a specific target with "--target <NAME>"
         run: cmake --build .
 
       - name: Run the Tests
-        # Use a bash shell so we can use the same syntax for environment variable
-        # access regardless of the host operating system
-        shell: bash
-        working-directory: ${{runner.workspace}}/build
+        working-directory: ${{ runner.workspace }}/build
         # Execute tests defined by the CMake configuration.
         # See https://cmake.org/cmake/help/latest/manual/ctest.1.html for more detail
         run: ctest

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -44,6 +44,9 @@ target_include_directories(pegtl INTERFACE
 # require C++17
 target_compile_features(pegtl INTERFACE cxx_std_17)
 
+option(PEGTL_USE_BOOST_FILESYSTEM "Override the auto-detection of std::filesystem and use Boost.Filesystem" OFF)
+
+# Try compiling a test program with std::filesystem or one of its alternatives
 function(check_filesystem_impl FILESYSTEM_HEADER FILESYSTEM_NAMESPACE OPTIONAL_LIBS OUT_RESULT)
   set(TEST_FILE "test_${OUT_RESULT}.cpp")
   configure_file(cmake/test_filesystem.cpp.in ${TEST_FILE} @ONLY)
@@ -74,26 +77,33 @@ function(check_filesystem_impl FILESYSTEM_HEADER FILESYSTEM_NAMESPACE OPTIONAL_L
   set(${OUT_RESULT} ${TEST_RESULT} PARENT_SCOPE)
 endfunction(check_filesystem_impl)
 
-# Try compiling a minimal program with each header/namespace, in order of preference:
-#   C++17: #include <filesystem> // std::filesystem
-#   Experimental C++17: #include <experimental/filesystem> // std::experimental::filesystem
-#   Boost.Filesystem: #include <boost/filesystem.hpp> // boost::filesystem
-check_filesystem_impl("filesystem" "std::filesystem" "stdc++fs;c++fs" STD_FILESYSTEM)
-if(STD_FILESYSTEM)
-  message(STATUS "Using std::filesystem.")
+if(PEGTL_USE_BOOST_FILESYSTEM)
+  # Force the use of Boost.Filesystem: #include <boost/filesystem.hpp> // boost::filesystem
+  find_package(Boost REQUIRED COMPONENTS filesystem)
+  target_link_libraries(${PROJECT_NAME} INTERFACE Boost::filesystem)
+  target_compile_definitions(${PROJECT_NAME} INTERFACE TAO_PEGTL_BOOST_FILESYSTEM)
 else()
-  check_filesystem_impl("experimental/filesystem" "std::experimental::filesystem" "stdc++fs;c++fs" STD_EXPERIMENTAL_FILESYSTEM)
-  if(STD_EXPERIMENTAL_FILESYSTEM)
-    target_compile_definitions(${PROJECT_NAME} INTERFACE TAO_PEGTL_STD_EXPERIMENTAL_FILESYSTEM)
-    message(WARNING "Using std::experimental::filesystem as a fallback.")
+  # Try compiling a minimal program with each header/namespace, in order of preference:
+  #   C++17: #include <filesystem> // std::filesystem
+  #   Experimental C++17: #include <experimental/filesystem> // std::experimental::filesystem
+  #   Boost.Filesystem: #include <boost/filesystem.hpp> // boost::filesystem
+  check_filesystem_impl("filesystem" "std::filesystem" "stdc++fs;c++fs" STD_FILESYSTEM)
+  if(STD_FILESYSTEM)
+    message(STATUS "Using std::filesystem")
   else()
-    find_package(Boost COMPONENTS filesystem)
-    check_filesystem_impl("boost/filesystem.hpp" "boost::filesystem" Boost::filesystem BOOST_FILESYSTEM)
-    if(BOOST_FILESYSTEM)
-      target_compile_definitions(${PROJECT_NAME} INTERFACE TAO_PEGTL_BOOST_FILESYSTEM)
-      message(WARNING "Using Boost.Filesystem as a fallback.")
+    check_filesystem_impl("experimental/filesystem" "std::experimental::filesystem" "stdc++fs;c++fs" STD_EXPERIMENTAL_FILESYSTEM)
+    if(STD_EXPERIMENTAL_FILESYSTEM)
+      target_compile_definitions(${PROJECT_NAME} INTERFACE TAO_PEGTL_STD_EXPERIMENTAL_FILESYSTEM)
+      message(WARNING "Using std::experimental::filesystem as a fallback")
     else()
-      message(FATAL_ERROR "PEGTL requires C++17, including an implementation of std::filesystem, which your compiler toolchain does not seem to support. You can try installing Boost.Filesystem as a temporary workaround, but there's no guarantee the PEGTL will keep working with your project. Consider upgrading your compiler toolchain or downgrading the PEGTL to the previous version.")
+      find_package(Boost COMPONENTS filesystem)
+      check_filesystem_impl("boost/filesystem.hpp" "boost::filesystem" Boost::filesystem BOOST_FILESYSTEM)
+      if(BOOST_FILESYSTEM)
+        target_compile_definitions(${PROJECT_NAME} INTERFACE TAO_PEGTL_BOOST_FILESYSTEM)
+        message(WARNING "Using Boost.Filesystem as a fallback")
+      else()
+        message(FATAL_ERROR "PEGTL requires C++17, including an implementation of std::filesystem, which your compiler toolchain does not seem to support. You can try installing Boost.Filesystem as a temporary workaround, but there's no guarantee the PEGTL will keep working with your project. Consider upgrading your compiler toolchain or downgrading the PEGTL to the previous version.")
+      endif()
     endif()
   endif()
 endif()

--- a/include/tao/pegtl/internal/file_mapper_posix.hpp
+++ b/include/tao/pegtl/internal/file_mapper_posix.hpp
@@ -41,7 +41,7 @@ namespace TAO_PEGTL_NAMESPACE::internal
          struct stat st;
          errno = 0;
          if( ::fstat( m_fd, &st ) < 0 ) {
-            const std::error_code ec( errno, std::system_category() );
+            internal::error_code ec( errno, internal::system_category() );
             throw internal::filesystem::filesystem_error( "fstat() failed", m_path, ec );
          }
          return std::size_t( st.st_size );
@@ -63,7 +63,7 @@ namespace TAO_PEGTL_NAMESPACE::internal
          if( fd >= 0 ) {
             return fd;
          }
-         const std::error_code ec( errno, std::system_category() );
+         internal::error_code ec( errno, internal::system_category() );
          throw internal::filesystem::filesystem_error( "open() failed", m_path, ec );
       }
    };
@@ -80,7 +80,7 @@ namespace TAO_PEGTL_NAMESPACE::internal
            m_data( static_cast< const char* >( ::mmap( nullptr, m_size, PROT_READ, MAP_PRIVATE, reader.m_fd, 0 ) ) )
       {
          if( ( m_size != 0 ) && ( intptr_t( m_data ) == -1 ) ) {
-            const std::error_code ec( errno, std::system_category() );
+            internal::error_code ec( errno, internal::system_category() );
             throw internal::filesystem::filesystem_error( "mmap() failed", reader.m_path, ec );
          }
       }

--- a/include/tao/pegtl/internal/file_mapper_win32.hpp
+++ b/include/tao/pegtl/internal/file_mapper_win32.hpp
@@ -54,7 +54,7 @@ namespace TAO_PEGTL_NAMESPACE::internal
       {
          LARGE_INTEGER size;
          if( !::GetFileSizeEx( m_handle, &size ) ) {
-            const std::error_code ec( ::GetLastError(), std::system_category() );
+            internal::error_code ec( ::GetLastError(), internal::system_category() );
             throw internal::filesystem::filesystem_error( "GetFileSizeEx() failed", m_path, ec );
          }
          return std::size_t( size.QuadPart );
@@ -76,7 +76,7 @@ namespace TAO_PEGTL_NAMESPACE::internal
          if( handle != INVALID_HANDLE_VALUE ) {
             return handle;
          }
-         const std::error_code ec( ::GetLastError(), std::system_category() );
+         internal::error_code ec( ::GetLastError(), internal::system_category() );
          throw internal::filesystem::filesystem_error( "CreateFile2() failed", m_path, ec );
 #else
          const HANDLE handle = ::CreateFileW( m_path.c_str(),
@@ -89,7 +89,7 @@ namespace TAO_PEGTL_NAMESPACE::internal
          if( handle != INVALID_HANDLE_VALUE ) {
             return handle;
          }
-         const std::error_code ec( ::GetLastError(), std::system_category() );
+         internal::error_code ec( ::GetLastError(), internal::system_category() );
          throw internal::filesystem::filesystem_error( "CreateFileW()", m_path, ec );
 #endif
       }
@@ -138,7 +138,7 @@ namespace TAO_PEGTL_NAMESPACE::internal
          if( handle != NULL || file_size == 0 ) {
             return handle;
          }
-         const std::error_code ec( ::GetLastError(), std::system_category() );
+         internal::error_code ec( ::GetLastError(), internal::system_category() );
          throw internal::filesystem::filesystem_error( "CreateFileMappingW() failed", reader.m_path, ec );
       }
    };
@@ -159,7 +159,7 @@ namespace TAO_PEGTL_NAMESPACE::internal
                                                                 0 ) ) )
       {
          if( ( m_size != 0 ) && ( intptr_t( m_data ) == 0 ) ) {
-            const std::error_code ec( ::GetLastError(), std::system_category() );
+            internal::error_code ec( ::GetLastError(), internal::system_category() );
             throw internal::filesystem::filesystem_error( "MapViewOfFile() failed", ec );
          }
       }

--- a/include/tao/pegtl/internal/file_reader.hpp
+++ b/include/tao/pegtl/internal/file_reader.hpp
@@ -23,7 +23,7 @@ namespace TAO_PEGTL_NAMESPACE::internal
       if( ::_wfopen_s( &file, path.c_str(), L"rb" ) == 0 ) {
          return file;
       }
-      const std::error_code ec( errno, std::system_category() );
+      internal::error_code ec( errno, internal::system_category() );
       throw internal::filesystem::filesystem_error( "_wfopen_s() failed", path, ec );
 #else
 #if defined( __MINGW32__ )
@@ -34,7 +34,7 @@ namespace TAO_PEGTL_NAMESPACE::internal
       {
          return file;
       }
-      const std::error_code ec( errno, std::system_category() );
+      internal::error_code ec( errno, internal::system_category() );
       throw internal::filesystem::filesystem_error( "std::fopen() failed", path, ec );
 #endif
    }
@@ -72,7 +72,7 @@ namespace TAO_PEGTL_NAMESPACE::internal
          errno = 0;
          if( std::fseek( m_file.get(), 0, SEEK_END ) != 0 ) {
             // LCOV_EXCL_START
-            const std::error_code ec( errno, std::system_category() );
+            internal::error_code ec( errno, internal::system_category() );
             throw internal::filesystem::filesystem_error( "std::fseek() failed [SEEK_END]", m_path, ec );
             // LCOV_EXCL_STOP
          }
@@ -80,14 +80,14 @@ namespace TAO_PEGTL_NAMESPACE::internal
          const auto s = std::ftell( m_file.get() );
          if( s < 0 ) {
             // LCOV_EXCL_START
-            const std::error_code ec( errno, std::system_category() );
+            internal::error_code ec( errno, internal::system_category() );
             throw internal::filesystem::filesystem_error( "std::ftell() failed", m_path, ec );
             // LCOV_EXCL_STOP
          }
          errno = 0;
          if( std::fseek( m_file.get(), 0, SEEK_SET ) != 0 ) {
             // LCOV_EXCL_START
-            const std::error_code ec( errno, std::system_category() );
+            internal::error_code ec( errno, internal::system_category() );
             throw internal::filesystem::filesystem_error( "std::fseek() failed [SEEK_SET]", m_path, ec );
             // LCOV_EXCL_STOP
          }
@@ -101,7 +101,7 @@ namespace TAO_PEGTL_NAMESPACE::internal
          errno = 0;
          if( !nrv.empty() && ( std::fread( &nrv[ 0 ], nrv.size(), 1, m_file.get() ) != 1 ) ) {
             // LCOV_EXCL_START
-            const std::error_code ec( errno, std::system_category() );
+            internal::error_code ec( errno, internal::system_category() );
             throw internal::filesystem::filesystem_error( "std::fread() failed", m_path, ec );
             // LCOV_EXCL_STOP
          }

--- a/include/tao/pegtl/internal/filesystem.hpp
+++ b/include/tao/pegtl/internal/filesystem.hpp
@@ -18,7 +18,7 @@ namespace TAO_PEGTL_NAMESPACE::internal
 
    using error_code = ::boost::system::error_code;
 
-   constexpr const auto& system_category() noexcept
+   const auto& system_category() noexcept
    {
       return ::boost::system::system_category();
    }
@@ -34,7 +34,7 @@ namespace TAO_PEGTL_NAMESPACE::internal
 
    using error_code = ::std::error_code;
 
-   constexpr const auto& system_category() noexcept
+   const auto& system_category() noexcept
    {
       return ::std::system_category();
    }
@@ -50,7 +50,7 @@ namespace TAO_PEGTL_NAMESPACE::internal
 
    using error_code = ::std::error_code;
 
-   constexpr const auto& system_category() noexcept
+   const auto& system_category() noexcept
    {
       return ::std::system_category();
    }

--- a/include/tao/pegtl/internal/filesystem.hpp
+++ b/include/tao/pegtl/internal/filesystem.hpp
@@ -22,7 +22,7 @@ namespace TAO_PEGTL_NAMESPACE::internal
    {
       return ::boost::system::system_category();
    }
-}
+}  // namespace TAO_PEGTL_NAMESPACE::internal
 
 #elif defined( TAO_PEGTL_STD_EXPERIMENTAL_FILESYSTEM )
 
@@ -38,7 +38,7 @@ namespace TAO_PEGTL_NAMESPACE::internal
    {
       return ::std::system_category();
    }
-}
+}  // namespace TAO_PEGTL_NAMESPACE::internal
 
 #else
 
@@ -54,7 +54,7 @@ namespace TAO_PEGTL_NAMESPACE::internal
    {
       return ::std::system_category();
    }
-}
+}  // namespace TAO_PEGTL_NAMESPACE::internal
 
 #endif
 

--- a/include/tao/pegtl/internal/filesystem.hpp
+++ b/include/tao/pegtl/internal/filesystem.hpp
@@ -6,16 +6,7 @@
 
 #include "../config.hpp"
 
-#if defined( TAO_PEGTL_STD_EXPERIMENTAL_FILESYSTEM )
-
-#include <experimental/filesystem>
-
-namespace TAO_PEGTL_NAMESPACE::internal
-{
-   namespace filesystem = ::std::experimental::filesystem;
-}
-
-#elif defined( TAO_PEGTL_BOOST_FILESYSTEM )
+#if defined( TAO_PEGTL_BOOST_FILESYSTEM )
 
 #define BOOST_FILESYSTEM_NO_DEPRECATED
 
@@ -24,6 +15,29 @@ namespace TAO_PEGTL_NAMESPACE::internal
 namespace TAO_PEGTL_NAMESPACE::internal
 {
    namespace filesystem = ::boost::filesystem;
+
+   using error_code = ::boost::system::error_code;
+
+   constexpr const auto& system_category() noexcept
+   {
+      return ::boost::system::system_category();
+   }
+}
+
+#elif defined( TAO_PEGTL_STD_EXPERIMENTAL_FILESYSTEM )
+
+#include <experimental/filesystem>
+
+namespace TAO_PEGTL_NAMESPACE::internal
+{
+   namespace filesystem = ::std::experimental::filesystem;
+
+   using error_code = ::std::error_code;
+
+   constexpr const auto& system_category() noexcept
+   {
+      return ::std::system_category();
+   }
 }
 
 #else
@@ -33,6 +47,13 @@ namespace TAO_PEGTL_NAMESPACE::internal
 namespace TAO_PEGTL_NAMESPACE::internal
 {
    namespace filesystem = ::std::filesystem;
+
+   using error_code = ::std::error_code;
+
+   constexpr const auto& system_category() noexcept
+   {
+      return ::std::system_category();
+   }
 }
 
 #endif

--- a/include/tao/pegtl/internal/path_to_string.hpp
+++ b/include/tao/pegtl/internal/path_to_string.hpp
@@ -13,12 +13,7 @@ namespace TAO_PEGTL_NAMESPACE::internal
 {
    [[nodiscard]] inline std::string path_to_string( const internal::filesystem::path& path )
    {
-#if defined( __cpp_char8_t )
-      const auto s = path.u8string();
-      return { reinterpret_cast< const char* >( s.data() ), s.size() };
-#else
-      return path.u8string();
-#endif
+      return path.string();
    }
 
 }  // namespace TAO_PEGTL_NAMESPACE::internal

--- a/include/tao/pegtl/internal/path_to_string.hpp
+++ b/include/tao/pegtl/internal/path_to_string.hpp
@@ -13,7 +13,14 @@ namespace TAO_PEGTL_NAMESPACE::internal
 {
    [[nodiscard]] inline std::string path_to_string( const internal::filesystem::path& path )
    {
+#if defined( TAO_PEGTL_BOOST_FILESYSTEM )
       return path.string();
+#elif defined( __cpp_char8_t )
+      const auto s = path.u8string();
+      return { reinterpret_cast< const char* >( s.data() ), s.size() };
+#else
+      return path.u8string();
+#endif
    }
 
 }  // namespace TAO_PEGTL_NAMESPACE::internal

--- a/src/test/pegtl/internal_file_mapper.cpp
+++ b/src/test/pegtl/internal_file_mapper.cpp
@@ -16,7 +16,7 @@ namespace TAO_PEGTL_NAMESPACE
          std::cerr << "pegtl: unit test failed for [ internal::file_mapper ]" << std::endl;
          ++failed;
       }
-      catch( const std::system_error& ) {
+      catch( const internal::filesystem::filesystem_error& ) {
       }
       catch( ... ) {
          std::cerr << "pegtl: unit test failed for [ internal::file_mapper ] with unexpected exception" << std::endl;

--- a/src/test/pegtl/verify_file.hpp
+++ b/src/test/pegtl/verify_file.hpp
@@ -62,7 +62,7 @@ namespace TAO_PEGTL_NAMESPACE
             parse< file_grammar >( in );
             TAO_PEGTL_TEST_ASSERT( !"no error on opening non-existing file" );
          }
-         catch( const std::system_error& ) {
+         catch( const internal::filesystem::filesystem_error& ) {
          }
       }
       {


### PR DESCRIPTION
I added an option to CMakeLists.txt called `PEGTL_USE_BOOST_FILESYSTEM`, which defaults to `OFF`. If enabled, it will bypass all of the `std::filesystem` auto-detection and behave as though it fell all the way back to Boost.Filesystem.

Doing that exposed some incompatibilities between the code which was still using `std::error_code` and `boost::filesystem::filesystem_error`, which expected a `boost::system::error_code`. So I needed to make `internal` namespace versions of a few more of those types and replace at least one `catch (const std::system_error& )` statement with a more specific `catch (const internal::filesystem::filesystem_error& )` in the tests. Normally `std::filesystem::filesystem_error` inherits from `std::system_error`.

I also switched `std-filesystem-fallbacks.yml` over to just testing with `PEGTL_USE_BOOST_FILESYSTEM`. While testing that, I noticed that the armv7 tests consistently failed in the `Main CI` workflow even though it built successfully. Since we can't run armv7 test binaries on an x86 runner, I added an `if` condition to the test step which suppresses the test runs if the image contains `armv7`. The `mingw` tests also seem to fail consistently, but I don't know if that's surmountable or not, so I left them as is.