### PR TITLE
Wrap filesystem paths in quotes

### DIFF
--- a/cmake/dummy-config.cmake.in
+++ b/cmake/dummy-config.cmake.in
@@ -2,4 +2,4 @@
 # When a dependency is added with add_subdirectory, but searched with find_package
 
 # Redirect to the directory added with add_subdirectory
-add_subdirectory(@PROJECT_SOURCE_DIR@ @PROJECT_BINARY_DIR@)
+add_subdirectory("@PROJECT_SOURCE_DIR@" "@PROJECT_BINARY_DIR@")


### PR DESCRIPTION
The [cppgraphqlgen](https://github.com/microsoft/cppgraphqlgen) project includes PEGTL as a submodule and looks for it with a minimum version number in `find_package`, so if you have a recent enough version installed on the system (e.g. with vcpkg) it will prefer the system version, but it will fall back to using `add_subdirectory` for the submodule if it's missing or not recent enough. 

I noticed when I bumped the submodule and CMake version number for PEGTL in cppgraphqlgen that I started getting CMake errors in `pegtl-config.cmake`.  VS 2019's default build config on my system is called "x64-Debug (default)", which has a space in it. When PEGTL configures the `pegtl-config.cmake` file, it doesn't escape or quote the filesystem paths, so the build directory that VS 2019 creates with that config name using a space by default breaks.