### PR TITLE
parse_tree::basic_node now uses template Source, defaults to string_view

### DIFF
--- a/include/tao/pegtl/contrib/parse_tree.hpp
+++ b/include/tao/pegtl/contrib/parse_tree.hpp
@@ -32,7 +32,7 @@
 
 namespace TAO_PEGTL_NAMESPACE::parse_tree
 {
-   template< typename T >
+   template< typename T, typename Source = std::string_view >
    struct basic_node
    {
       using node_t = T;
@@ -40,7 +40,7 @@ namespace TAO_PEGTL_NAMESPACE::parse_tree
       children_t children;
 
       std::string_view type;
-      std::string source;
+      Source source;
 
       TAO_PEGTL_NAMESPACE::internal::iterator m_begin;
       TAO_PEGTL_NAMESPACE::internal::iterator m_end;


### PR DESCRIPTION
There is no reason to copy the string over and over again, most of the
time the source will be alive and a string_view will be enough.

If there is any case where this is not the case, then `basic_node` can
be told to use a different type via the second template parameter.

Closes #243