### PR TITLE
parse_tree::basic_node check hash_code() before demangled string

### DIFF
--- a/include/tao/pegtl/contrib/parse_tree.hpp
+++ b/include/tao/pegtl/contrib/parse_tree.hpp
@@ -39,6 +39,7 @@ namespace TAO_PEGTL_NAMESPACE::parse_tree
       using children_t = std::vector< std::unique_ptr< node_t > >;
       children_t children;
 
+      size_t type_hash;
       std::string_view type;
       std::string source;
 
@@ -67,12 +68,13 @@ namespace TAO_PEGTL_NAMESPACE::parse_tree
       template< typename U >
       [[nodiscard]] bool is_type() const noexcept
       {
-         return type == demangle< U >();
+         return type_hash == typeid( U ).hash_code() && type == demangle< U >();
       }
 
       template< typename U >
       void set_type() noexcept
       {
+         type_hash = typeid( U ).hash_code();
          type = demangle< U >();
       }
 


### PR DESCRIPTION
typeid().hash_code() guarantees the same type will have the same
hash_code. Since it's fixed size (size_t) and much faster/simpler to
compare, use it in `is_type()`.

However, different types can have the same hash_code(). It is not
common, but is possible, then we must compare the strings afterwards.

Closes: #244