### PR TITLE
Simplify ranges implementation

### DIFF
--- a/include/tao/pegtl/internal/ranges.hpp
+++ b/include/tao/pegtl/internal/ranges.hpp
@@ -36,7 +36,9 @@ namespace TAO_PEGTL_NAMESPACE::internal
          if constexpr( sizeof...( Cs ) % 2 == 1 ) {
             return c == cs[ sizeof...( Cs ) - 1 ];
          }
-         return false;
+         else {
+            return false;
+         }
       }
 
       template< int Eol >


### PR DESCRIPTION
Using a constexpr array to replace recursive function calls.

By tests, compilers are smart enough to expand this for-loop and inline array elements. No need to worry about efficiency. See https://godbolt.org/z/cc9W3M.

Besides, my version will throw invalid ranges error earlier.

If you really want determined inlining and expansion, you may check this approach:

```cpp
#include <iostream>

template<char l_, char r_>
struct CR {
    static_assert(l_ < r_);
    static constexpr char l = l_;
    static constexpr char r = r_;
};

template<char...>
struct CharHelper {};

template<class T, class... Ts>
struct RangeHelper {};

template<class... Ts>
struct RangeHelper<CharHelper<>, Ts...> {
    static void test(char c) {
        if (((Ts::l <= c && c <= Ts::r) || ...)) {
            std::cout << "success\n";
        } else {
            std::cout << "fail\n";
        }
    }
};

template<char C1, char C2, char... Cs, class... Ts>
struct RangeHelper<CharHelper<C1, C2, Cs...>, Ts...>
    : RangeHelper<CharHelper<Cs...>, Ts..., CR<C1, C2>> {};

template<char... Cs>
struct Range: RangeHelper<CharHelper<Cs...>> {
    static_assert(sizeof...(Cs) % 2 == 0);
};

int main() {
    Range<'a', 'z', 'A', 'Z'>::test('x');
}
```