### PR TITLE
Documentation: change src/examples/ to src/example/

### DIFF
--- a/doc/Actions-and-States.md
+++ b/doc/Actions-and-States.md
@@ -286,7 +286,7 @@ std::string unescape( const std::string& escaped )
 
 At the end of the parsing run, the complete unescaped string can be found in the aptly named variable `unescaped`.
 
-A more complete example of how to unescape strings can be found in `src/examples/pegtl/unescape.cpp`.
+A more complete example of how to unescape strings can be found in `src/example/pegtl/unescape.cpp`.
 
 ## Specialising
 

--- a/doc/Errors-and-Exceptions.md
+++ b/doc/Errors-and-Exceptions.md
@@ -162,7 +162,7 @@ This is often insufficient and one would like to provide more meaningful error m
 
 A practical technique to provide customised error messages for all `must<>` error points uses the `must_if<>` helper.
 
-For an example of this method see `src/examples/pegtl/json_errors.hpp`, where all errors that might occur in the supplied JSON grammar are customised like this:
+For an example of this method see `src/example/pegtl/json_errors.hpp`, where all errors that might occur in the supplied JSON grammar are customised like this:
 
 ```c++
 template< typename > inline constexpr const char* error_message = nullptr;


### PR DESCRIPTION
Hello

I just started trying out pegtl and it is working great so far!

In the process of trying it, I spotted a few file paths in the documentation that referred to `src/examples`, which does not exist. I fixed the paths to `src/example/` in this pull request.