### PR TITLE
fix dec_octet in contrib/uri grammar

### DIFF
--- a/include/tao/pegtl/contrib/uri.hpp
+++ b/include/tao/pegtl/contrib/uri.hpp
@@ -32,7 +32,11 @@ namespace TAO_PEGTL_NAMESPACE::uri
    using colon = one< ':' >;
 
    // clang-format off
-   struct dec_octet : maximum_rule< std::uint8_t > {};
+   struct dec_octet : sor<
+      rep_min_max< 1, 2, abnf::DIGIT >,
+      seq< one< '1' >, rep< 2, abnf::DIGIT > >,
+      seq< one< '2' >, range< '0', '4' >, abnf::DIGIT >,
+      seq< one< '2' >, one< '5' >, range< '0', '5' > > > {};
 
    struct IPv4address : seq< dec_octet, dot, dec_octet, dot, dec_octet, dot, dec_octet > {};
 

--- a/src/test/pegtl/contrib_uri.cpp
+++ b/src/test/pegtl/contrib_uri.cpp
@@ -40,6 +40,7 @@ namespace TAO_PEGTL_NAMESPACE
       verify_rule< GRAMMAR >( __LINE__, __FILE__, "git://github.com/rails/rails.git", result_type::success, 0 );
       verify_rule< GRAMMAR >( __LINE__, __FILE__, "crid://broadcaster.com/movies/BestActionMovieEver", result_type::success, 0 );
       verify_rule< GRAMMAR >( __LINE__, __FILE__, "http://nobody:password@example.org:8080/cgi-bin/script.php?action=submit&pageid=86392001#section_2", result_type::success, 0 );
+      verify_rule< GRAMMAR >( __LINE__, __FILE__, "http://256test.com", result_type::success, 0 );
 
       TAO_PEGTL_TEST_THROWS( parse< GRAMMAR >( memory_input( "", "" ) ) );
    }


### PR DESCRIPTION
The grammar for dec_octet does not conform RFC, it should not allow any
octet, but rather [0-255].