### PR TITLE
Replace try/catch/rethrow in unwind with unwind_guard

### DIFF
--- a/include/tao/pegtl/contrib/parse_tree.hpp
+++ b/include/tao/pegtl/contrib/parse_tree.hpp
@@ -232,18 +232,6 @@ namespace tao::pegtl::parse_tree
          using type = rotate_states_right< state_handler< Rule, is_selected_node< Rule, Selector >, is_leaf< 8, typename Rule::subs_t, Selector > > >;
       };
 
-      template< typename, typename, typename... >
-      inline constexpr bool node_has_unwind = false;
-
-      template< typename Node, typename Rule, typename... States >
-      inline constexpr bool node_has_unwind< Node,
-                                             Rule,
-                                             decltype( std::declval< Node >().template unwind< Rule >( std::declval< States >()... ) ),
-                                             States... > = true;
-
-      template< typename Control, typename... States >
-      inline constexpr bool control_has_unwind = tao::pegtl::internal::has_unwind< Control, void, States... >;
-
       template< typename Node, template< typename... > class Selector, template< typename... > class Control >
       template< typename Rule >
       struct make_control< Node, Selector, Control >::state_handler< Rule, false, true >
@@ -323,11 +311,9 @@ namespace tao::pegtl::parse_tree
          template< typename ParseInput, typename... States >
          static void unwind( const ParseInput& in, state< Node >& state, States&&... st )
          {
-            if constexpr( node_has_unwind< Node, Rule, void, const ParseInput&, States... > ) {
-               state.back()->template unwind< Rule >( in, st... );
-            }
+            state.back()->template unwind< Rule >( in, st... );
             state.pop_back();
-            if constexpr( control_has_unwind< Control< Rule >, const ParseInput&, States... > ) {
+            if constexpr( tao::pegtl::internal::has_unwind< Control< Rule >, void, const ParseInput&, States... > ) {
                Control< Rule >::unwind( in, st... );
             }
          }

--- a/include/tao/pegtl/contrib/parse_tree.hpp
+++ b/include/tao/pegtl/contrib/parse_tree.hpp
@@ -280,8 +280,7 @@ namespace tao::pegtl::parse_tree
          }
 
          template< typename ParseInput, typename... States >
-         static auto unwind( const ParseInput& /*unused*/, state< Node >& state, States&&... /*unused*/ )
-            -> std::enable_if_t< node_has_unwind< Node, Rule, void, const ParseInput&, States... > || control_has_unwind< Control< Rule >, const ParseInput&, States... >, void >
+         static void unwind( const ParseInput& /*unused*/, state< Node >& state, States&&... /*unused*/ )
          {
             state.pop_back();
          }
@@ -322,8 +321,7 @@ namespace tao::pegtl::parse_tree
          }
 
          template< typename ParseInput, typename... States >
-         static auto unwind( const ParseInput& in, state< Node >& state, States&&... st )
-            -> std::enable_if_t< node_has_unwind< Node, Rule, void, const ParseInput&, States... > || control_has_unwind< Control< Rule >, const ParseInput&, States... >, void >
+         static void unwind( const ParseInput& in, state< Node >& state, States&&... st )
          {
             if constexpr( node_has_unwind< Node, Rule, void, const ParseInput&, States... > ) {
                state.back()->template unwind< Rule >( in, st... );

--- a/include/tao/pegtl/internal/unwind_guard.hpp
+++ b/include/tao/pegtl/internal/unwind_guard.hpp
@@ -1,0 +1,39 @@
+// Copyright (c) 2014-2022 Dr. Colin Hirsch and Daniel Frey
+// Distributed under the Boost Software License, Version 1.0.
+// (See accompanying file LICENSE_1_0.txt or copy at https://www.boost.org/LICENSE_1_0.txt)
+
+#ifndef TAO_PEGTL_INTERNAL_UNWIND_GUARD_HPP
+#define TAO_PEGTL_INTERNAL_UNWIND_GUARD_HPP
+
+#include <functional>
+#include <optional>
+#include <type_traits>
+
+namespace tao::pegtl::internal
+{
+   template< typename Unwind >
+   struct unwind_guard
+   {
+      explicit unwind_guard( Unwind&& unwind_impl )
+         : unwind( std::move( unwind_impl ) )
+      {
+      }
+
+      ~unwind_guard()
+      {
+         if( unwind ) {
+            ( *unwind )();
+         }
+      }
+
+      unwind_guard( const unwind_guard& ) = delete;
+      unwind_guard( unwind_guard&& ) noexcept = delete;
+      unwind_guard& operator=( const unwind_guard& ) = delete;
+      unwind_guard& operator=( unwind_guard&& ) noexcept = delete;
+
+      std::optional< Unwind > unwind;
+   };
+
+}  // namespace tao::pegtl::internal
+
+#endif

--- a/include/tao/pegtl/internal/unwind_guard.hpp
+++ b/include/tao/pegtl/internal/unwind_guard.hpp
@@ -5,9 +5,7 @@
 #ifndef TAO_PEGTL_INTERNAL_UNWIND_GUARD_HPP
 #define TAO_PEGTL_INTERNAL_UNWIND_GUARD_HPP
 
-#include <functional>
 #include <optional>
-#include <type_traits>
 
 namespace tao::pegtl::internal
 {

--- a/include/tao/pegtl/internal/unwind_guard.hpp
+++ b/include/tao/pegtl/internal/unwind_guard.hpp
@@ -6,6 +6,7 @@
 #define TAO_PEGTL_INTERNAL_UNWIND_GUARD_HPP
 
 #include <optional>
+#include <utility>
 
 namespace tao::pegtl::internal
 {

--- a/include/tao/pegtl/match.hpp
+++ b/include/tao/pegtl/match.hpp
@@ -5,8 +5,6 @@
 #ifndef TAO_PEGTL_MATCH_HPP
 #define TAO_PEGTL_MATCH_HPP
 
-#include <functional>
-#include <optional>
 #include <type_traits>
 
 #include "apply_mode.hpp"

--- a/include/tao/pegtl/match.hpp
+++ b/include/tao/pegtl/match.hpp
@@ -75,7 +75,7 @@ namespace tao::pegtl
       {
 #if defined( __cpp_exceptions )
          if constexpr( has_unwind< Control< Rule >, void, const ParseInput&, States... > ) {
-            unwind_guard ug( [ &in, &st... ]() {
+            unwind_guard ug( [ & ]() {
                Control< Rule >::unwind( static_cast< const ParseInput& >( in ), st... );
             } );
             auto result = match_no_control< Rule, A, M, Action, Control >( in, st... );

--- a/include/tao/pegtl/match.hpp
+++ b/include/tao/pegtl/match.hpp
@@ -65,24 +65,24 @@ namespace tao::pegtl
       struct unwind_guard
       {
          explicit unwind_guard( Unwind&& impl )
-            : impl( std::move( impl ) )
+            : unwind_impl( std::move( impl ) )
          {
          }
 
          ~unwind_guard()
          {
-            if( impl ) {
-               ( *impl )();
+            if( unwind_impl ) {
+               ( *unwind_impl )();
             }
          }
 
          void clear()
          {
-            impl.reset();
+            unwind_impl.reset();
          }
 
       private:
-         std::optional< Unwind > impl;
+         std::optional< Unwind > unwind_impl;
       };
 
       template< typename Rule,

--- a/include/tao/pegtl/match.hpp
+++ b/include/tao/pegtl/match.hpp
@@ -69,6 +69,11 @@ namespace tao::pegtl
          {
          }
 
+         unwind_guard( const unwind_guard& ) = delete;
+         unwind_guard( unwind_guard&& ) noexcept = delete;
+         unwind_guard& operator=( const unwind_guard& ) = delete;
+         unwind_guard& operator=( unwind_guard&& ) noexcept = delete;
+
          ~unwind_guard()
          {
             if( unwind_impl ) {


### PR DESCRIPTION
I noticed while investigating https://github.com/microsoft/cppgraphqlgen/issues/222 that `parse_tree` implements `unwind` on the `make_control<>::state_handler<>` struct, and this results in creating a try/catch/rethrow block around every rule match in `match_control_unwind`. Every try/catch/rethrow seems to be consuming significant stack space, so if you `raise`/throw an exception from a relatively shallow (< 20) nested rule, it often exhausts the stack.

This change makes it so `parse_tree` will only implement `unwind` on the `Control` type wrapper if either the `Control` or the `Node` type implements it. When parsing into a tree that doesn't implement either of them, the exception will be thrown once all the way from the initial `raise` to the caller of `parse_tree::parse`.

Since the unit tests use the default `node` which inherits `basic_node`, they still implement `unwind`. The unit tests also wrap the rule in a `try_catch_type` handler, though, so the exception doesn't bubble all the way up. Before I nailed down the `constexpr bool` definitions, I accidentally suppressed `unwind` for `basic_node` types in the unit tests as well, and the lack of `stack.pop_back()` calls resulted in the `assert(stack.size() == 1)` firing for the unit test. So that tells me this is incompatible with `try_catch_type`. That's the only thing I think might block it.