### PR TITLE
Workaround broken `__FUNCSIG__`

### DIFF
--- a/include/tao/pegtl/demangle.hpp
+++ b/include/tao/pegtl/demangle.hpp
@@ -99,6 +99,8 @@ template< typename T >
 
 #elif defined( _MSC_VER )
 
+#if( _MSC_VER < 1932 )
+
 template< typename T >
 [[nodiscard]] constexpr std::string_view tao::pegtl::demangle() noexcept
 {
@@ -112,6 +114,27 @@ template< typename T >
       return tmp.substr( 0, end );
    }
 }
+
+#else
+
+#if !defined( __cpp_rtti )
+#error "RTTI support required for MSVC 19.32"
+#else
+
+#include <typeinfo>
+
+// MSVC 19.32 has a bug where __FUNCSIG__ does not include the function's template parameters,
+// see https://developercommunity.visualstudio.com/t/C-__FUNCSIG__-macro-does-not-include-t/10040930
+template< typename T >
+[[nodiscard]] constexpr std::string_view tao::pegtl::demangle() noexcept
+{
+   // fallback: requires RTTI, no demangling
+   return typeid( T ).name();
+}
+
+#endif
+
+#endif
 
 #else
 


### PR DESCRIPTION
I verified that my project works with this change against main. I'd love to get this backported to a 3.2.6 release as well, since that would be a smaller change for me to adopt in my project.