### PR TITLE
Remove problematic language from the code

### DIFF
--- a/doc/Parse-Tree.md
+++ b/doc/Parse-Tree.md
@@ -57,8 +57,8 @@ template<> struct my_selector< my_rule_3 > : std::true_type {};
 auto root = tao::pegtl::parse_tree::parse< my_grammar, my_selector >( in );
 ```
 
-Note that the example uses a white-list style; the default is `std::false_type` and only rules listed with a specialisation deriving from `std::true_type` will generate nodes.
-The opposite, a black-list style, is of course possible, too.
+Note that the example uses an allow-list style; the default is `std::false_type` and only rules listed with a specialisation deriving from `std::true_type` will generate nodes.
+The opposite, a block-list style, is of course possible, too.
 
 The PEGTL includes a selector class and additional utility classes to allow for a less verbose specification of a selector.
 The following definition of `my_selector` will behave just like the one above.


### PR DESCRIPTION
Hello,

I would like to replace problematic terms with alternatives that are appropriate to the particular project and context. 
Similar to https://github.com/taocpp/PEGTL/commit/731bc8ff92feb41a09efa31d7b8f74a8af132d77, rename:
- white-list to allow-list
- black-list to block-list

