### PR TITLE
Update actions/checkout in GitHub Actions workflows to v3

### DIFF
--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -32,7 +32,7 @@ jobs:
       options: --user root
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       - run: cmake -H$GITHUB_WORKSPACE -B/home/developer/build -GNinja -DCMAKE_TOOLCHAIN_FILE=$ANDROID_NDK_HOME/build/cmake/android.toolchain.cmake -DANDROID_ABI=${{ matrix.abi }} -DANDROID_PLATFORM=${{ matrix.platform }} -DCMAKE_BUILD_TYPE=${{ matrix.build_type }}
 

--- a/.github/workflows/clang-analyze.yml
+++ b/.github/workflows/clang-analyze.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
 
     - run: sudo apt-get update -yq
 

--- a/.github/workflows/clang-format.yml
+++ b/.github/workflows/clang-format.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - uses: DoozyX/clang-format-lint-action@v0.13
       with:
         extensions: 'hpp,cpp'

--- a/.github/workflows/clang-tidy.yml
+++ b/.github/workflows/clang-tidy.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
 
     - run: sudo apt-get update -yq
 

--- a/.github/workflows/code-coverage.yml
+++ b/.github/workflows/code-coverage.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
 
     - run: cmake -E make_directory build
 

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -41,7 +41,7 @@ jobs:
 
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
 
     # Initializes the CodeQL tools for scanning.
     - name: Initialize CodeQL

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -29,7 +29,7 @@ jobs:
       CXX: ${{ matrix.compiler }}
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
 
     - run: cmake -E make_directory build
 
@@ -58,7 +58,7 @@ jobs:
       CXX: ${{ matrix.compiler }}
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
 
     - run: cmake -E make_directory build
 
@@ -89,7 +89,7 @@ jobs:
       CXX: ${{ matrix.compiler }}
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
 
     - run: sudo apt-get update -yq
 
@@ -116,7 +116,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
 
     - run: cmake -E make_directory build
 
@@ -142,7 +142,7 @@ jobs:
       CXX: clang++
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
 
     - run: cmake -E make_directory build
 

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -21,7 +21,7 @@ jobs:
     runs-on: macos-latest
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
 
     - uses: maxim-lobanov/setup-xcode@v1
       with:

--- a/.github/workflows/no-exceptions.yml
+++ b/.github/workflows/no-exceptions.yml
@@ -24,7 +24,7 @@ jobs:
       CXX: ${{ matrix.compiler }}
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
 
     - run: cmake -E make_directory build
 

--- a/.github/workflows/sanitizer.yml
+++ b/.github/workflows/sanitizer.yml
@@ -24,7 +24,7 @@ jobs:
       CXX: ${{ matrix.cxx }}
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
 
     - run: cmake -E make_directory build
 

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -20,7 +20,7 @@ jobs:
     runs-on: windows-latest
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
 
     - run: cmake -E make_directory build
 
@@ -43,7 +43,7 @@ jobs:
     runs-on: windows-latest
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
 
     - run: cmake -E make_directory build
 
@@ -66,7 +66,7 @@ jobs:
     runs-on: windows-2019
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
 
     - run: cmake -E make_directory build
 
@@ -89,7 +89,7 @@ jobs:
     runs-on: windows-2019
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
 
     - run: cmake -E make_directory build
 


### PR DESCRIPTION
Updates the `actions/checkout` action used in the GitHub Actions workflow to its newest major version.

Changes in [actions/checkout](https://github.com/actions/checkout):

> ## v3.1.0
> - Use @actions/core `saveState` and `getState`
> - Add `github-server-url` input
>
> ## v3.0.2
> - Add input `set-safe-directory`
>
> ## v3.0.1
> - Fixed an issue where checkout failed to run in container jobs due to the new git setting `safe.directory`
> - Bumped various npm package versions
>
> ## v3.0.0
>
> - Update to node 16

Still using v2 of `actions/checkout` will generate some warning like in this run: https://github.com/taocpp/PEGTL/actions/runs/3865860231

> Node.js 12 actions are deprecated. For more information see: https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/. Please update the following actions to use Node.js 16: actions/checkout@v2, github/codeql-action/init@v1, github/codeql-action/autobuild@v1, github/codeql-action/analyze@v1

The PR will get rid of those warnings for `actions/checkout`, because v3 uses Node.js 16.

The CodeQL action warnings will be fixed when merging https://github.com/taocpp/PEGTL/pull/327.