### PR TITLE
Fix workflow failure for older compilers on Linux

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -83,7 +83,7 @@ jobs:
           - clang++-9
         build_type: [Debug, Release]
 
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
 
     env:
       CXX: ${{ matrix.compiler }}


### PR DESCRIPTION
Those older compilers are not available on the `ubuntu-latest` runner images, because that currently is Ubuntu 22.04. However, they are available on Ubuntu 20.04, so we can use that instead.

For an example of the failure see https://github.com/taocpp/PEGTL/actions/runs/3658049428/jobs/6182351812. It fails on Ubuntu 22.04, because there is no corresponding package to install for the compiler. However, it worked on earlier runs that ran on Ubuntu 20.04, e. g. https://github.com/taocpp/PEGTL/actions/runs/2673168824/jobs/4164038853. Therefore, the switch to `ubuntu-20.04` should fix the `linux-old` workflow.