### PR TITLE
Fix clang-format warning in parse_tree.hpp

### DIFF
--- a/include/tao/pegtl/contrib/parse_tree.hpp
+++ b/include/tao/pegtl/contrib/parse_tree.hpp
@@ -234,8 +234,7 @@ namespace tao::pegtl::parse_tree
       inline constexpr bool node_has_unwind< Node,
                                              Rule,
                                              decltype( std::declval< Node >().template unwind< Rule >( std::declval< States >()... ) ),
-                                             States... >
-         = true;
+                                             States... > = true;
 
       template< typename Control, typename... States >
       inline constexpr bool control_has_unwind = tao::pegtl::internal::has_unwind< Control, void, States... >;


### PR DESCRIPTION
This pull request fixes a clang-format warning in parse_tree.hpp as seen e. g. in [this earlier workflow run](https://github.com/taocpp/PEGTL/actions/runs/3900307726/jobs/6660823600) where the following change is proposed by clang-format:

```
--- ./include/tao/pegtl/contrib/parse_tree.hpp	(original)
+++ ./include/tao/pegtl/contrib/parse_tree.hpp	(reformatted)
@@ -234,8 +234,7 @@
       inline constexpr bool node_has_unwind< Node,
                                              Rule,
                                              decltype( std::declval< Node >().template unwind< Rule >( std::declval< States >()... ) ),
-                                             States... >
-         = true;
+                                             States... > = true;
 
       template< typename Control, typename... States >
       inline constexpr bool control_has_unwind = tao::pegtl::internal::has_unwind< Control, void, States... >;
```

The PR just applies that change. As a result, the clang-format workflow should pass again.