### PR TITLE
Fix CI jobs for clang++-10 and clang++-11

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -23,7 +23,7 @@ jobs:
           - clang++-12
         build_type: [Debug, Release]
 
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
 
     env:
       CXX: ${{ matrix.compiler }}


### PR DESCRIPTION
The builds using `clang++-10` and `clang++11` are currently failing, see e. g. https://github.com/taocpp/PEGTL/actions/runs/3900307740/jobs/6660825997 or https://github.com/taocpp/PEGTL/actions/runs/3900307740/jobs/6660826294.

Those versions of Clang are only available on the Ubuntu 20.04 runner image for GitHub Actions, not on Ubuntu 22.04 (which is what `ubuntu-latest` currently is). Therefore, the switch to Ubuntu 20.04 should make those jobs pass again.