### PR TITLE
Feature/propagate node

### DIFF
--- a/include/tao/pegtl/contrib/parse_tree.hpp
+++ b/include/tao/pegtl/contrib/parse_tree.hpp
@@ -292,7 +292,7 @@ namespace tao::pegtl::parse_tree
          {
             state.emplace_back();
             state.back()->template start< Rule >( in, st... );
-            auto &n = state.back()->children.back();
+            auto& n = state.back()->children.back();
             Control< Rule >::start( in, n, st... );
          }
 
@@ -306,7 +306,8 @@ namespace tao::pegtl::parse_tree
             if( n ) {
                state.back()->emplace_back( std::move( n ), st... );
                Control< Rule >::success( in, state.back()->children.back(), st... );
-            } else {
+            }
+            else {
                 auto null_child = std::make_unique<Node>();
                 Control< Rule >::success( in, null_child, st... );
             }

--- a/include/tao/pegtl/contrib/parse_tree.hpp
+++ b/include/tao/pegtl/contrib/parse_tree.hpp
@@ -292,7 +292,8 @@ namespace tao::pegtl::parse_tree
          {
             state.emplace_back();
             state.back()->template start< Rule >( in, st... );
-            Control< Rule >::start( in, state.back()->children.back(), st... );
+            auto &n = state.back()->children.back();
+            Control< Rule >::start( in, n, st... );
          }
 
          template< typename ParseInput, typename... States >

--- a/include/tao/pegtl/contrib/parse_tree.hpp
+++ b/include/tao/pegtl/contrib/parse_tree.hpp
@@ -290,9 +290,9 @@ namespace tao::pegtl::parse_tree
          template< typename ParseInput, typename... States >
          static void start( const ParseInput& in, state< Node >& state, States&&... st )
          {
-            Control< Rule >::start( in, st... );
             state.emplace_back();
             state.back()->template start< Rule >( in, st... );
+            Control< Rule >::start( in, state.back()->children.back(), st... );
          }
 
          template< typename ParseInput, typename... States >
@@ -304,16 +304,19 @@ namespace tao::pegtl::parse_tree
             transform< Selector< Rule > >( in, n, st... );
             if( n ) {
                state.back()->emplace_back( std::move( n ), st... );
+               Control< Rule >::success( in, state.back()->children.back(), st... );
+            } else {
+                auto null_child = std::make_unique<Node>();
+                Control< Rule >::success( in, null_child, st... );
             }
-            Control< Rule >::success( in, st... );
          }
 
          template< typename ParseInput, typename... States >
          static void failure( const ParseInput& in, state< Node >& state, States&&... st )
          {
             state.back()->template failure< Rule >( in, st... );
+            Control< Rule >::failure( in, state.back()->children.back(), st... );
             state.pop_back();
-            Control< Rule >::failure( in, st... );
          }
 
          template< typename ParseInput, typename... States >

--- a/include/tao/pegtl/contrib/parse_tree.hpp
+++ b/include/tao/pegtl/contrib/parse_tree.hpp
@@ -308,8 +308,8 @@ namespace tao::pegtl::parse_tree
                Control< Rule >::success( in, state.back()->children.back(), st... );
             }
             else {
-                auto null_child = std::make_unique<Node>();
-                Control< Rule >::success( in, null_child, st... );
+               auto null_child = std::make_unique<Node>();
+               Control< Rule >::success( in, null_child, st... );
             }
          }
 


### PR DESCRIPTION
While creating a parse tree, it would be nice to propagate the current node to the user's control methods, (e.g. start, success, failure).

This way the user has additional control over handling the nodes of the tree.