### PR TITLE
separated_seq for 2.x

### DIFF
--- a/include/tao/pegtl/contrib/separated_seq.hpp
+++ b/include/tao/pegtl/contrib/separated_seq.hpp
@@ -1,0 +1,47 @@
+// Copyright (c) 2021-2022 Dr. Colin Hirsch and Daniel Frey
+// Please see LICENSE for license or visit https://github.com/taocpp/PEGTL/
+
+#ifndef TAO_PEGTL_CONTRIB_SEPARATED_SEQ_HPP
+#define TAO_PEGTL_CONTRIB_SEPARATED_SEQ_HPP
+
+#include "../config.hpp"
+
+#include "../internal/seq.hpp"
+#include "../type_list.hpp"
+
+namespace tao
+{
+   namespace TAO_PEGTL_NAMESPACE
+   {
+      namespace internal
+      {
+         template< typename... >
+         struct sep;
+
+         template< typename... Ts, typename S, typename Rule, typename... Rules >
+         struct sep< type_list< Ts... >, S, Rule, Rules... >
+            : sep< type_list< Ts..., Rule, S >, S, Rules... >
+         {};
+
+         template< typename... Ts, typename S, typename Rule >
+         struct sep< type_list< Ts... >, S, Rule >
+         {
+            using type = internal::seq< Ts..., Rule >;
+         };
+
+         template< typename S >
+         struct sep< type_list<>, S >
+         {
+            using type = internal::seq<>;
+         };
+
+      }  // namespace internal
+
+      template< typename S, typename... Rules >
+      struct separated_seq
+         : internal::sep< type_list<>, S, Rules... >::type
+      {};
+
+   }  // namespace TAO_PEGTL_NAMESPACE
+}  // namespace tao
+#endif

--- a/include/tao/pegtl/type_list.hpp
+++ b/include/tao/pegtl/type_list.hpp
@@ -1,0 +1,49 @@
+// Copyright (c) 2020-2022 Dr. Colin Hirsch and Daniel Frey
+// Please see LICENSE for license or visit https://github.com/taocpp/PEGTL/
+
+#ifndef TAO_PEGTL_TYPE_LIST_HPP
+#define TAO_PEGTL_TYPE_LIST_HPP
+
+#include <cstddef>
+
+#include "config.hpp"
+
+namespace tao
+{
+   namespace TAO_PEGTL_NAMESPACE
+   {
+      template< typename... Ts >
+      struct type_list
+      {
+         static constexpr std::size_t size = sizeof...( Ts );
+      };
+
+      using empty_list = type_list<>;
+
+      template< typename... >
+      struct type_list_concat;
+
+      template<>
+      struct type_list_concat<>
+      {
+         using type = empty_list;
+      };
+
+      template< typename... Ts >
+      struct type_list_concat< type_list< Ts... > >
+      {
+         using type = type_list< Ts... >;
+      };
+
+      template< typename... T0s, typename... T1s, typename... Ts >
+      struct type_list_concat< type_list< T0s... >, type_list< T1s... >, Ts... >
+         : type_list_concat< type_list< T0s..., T1s... >, Ts... >
+      {};
+
+      template< typename... Ts >
+      using type_list_concat_t = typename type_list_concat< Ts... >::type;
+
+   }  // namespace TAO_PEGTL_NAMESPACE
+}  // namespace tao
+
+#endif

--- a/src/test/pegtl/CMakeLists.txt
+++ b/src/test/pegtl/CMakeLists.txt
@@ -33,6 +33,7 @@ set(test_sources
   contrib_partial_trace.cpp
   contrib_raw_string.cpp
   contrib_rep_one_min_max.cpp
+  contrib_separated_seq.cpp
   contrib_to_string.cpp
   contrib_tracer.cpp
   contrib_unescape.cpp

--- a/src/test/pegtl/contrib_separated_seq.cpp
+++ b/src/test/pegtl/contrib_separated_seq.cpp
@@ -1,0 +1,25 @@
+// Copyright (c) 2021-2022 Dr. Colin Hirsch and Daniel Frey
+// Please see LICENSE for license or visit https://github.com/taocpp/PEGTL/
+
+#include <tao/pegtl.hpp>
+#include <tao/pegtl/contrib/separated_seq.hpp>
+
+#include <type_traits>
+
+namespace tao
+{
+   using namespace TAO_PEGTL_NAMESPACE;
+   // clang-format off
+   struct A : one<'0'> {};
+   struct B {};
+   struct C {};
+   struct D {};
+   
+   struct S {};
+   // clang-format on
+
+   static_assert( std::is_base_of< internal::seq<>, separated_seq< S > >::value );
+   static_assert( std::is_base_of< internal::seq< A >, separated_seq< S, A > >::value );
+   static_assert( std::is_base_of< internal::seq< A, S, B >, separated_seq< S, A, B > >::value );
+   static_assert( std::is_base_of< internal::seq< A, S, B, S, C, S, D >, separated_seq< S, A, B, C, D > >::value );
+}  // namespace tao


### PR DESCRIPTION
i needed separated_seq for project which was written in c++11 standart, so i copied separated_seq from 3.x version and applied minimum fixes for it to work on c++11 