### PR TITLE
Validate PEGTL tests when no filesystem is configured

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -23,7 +23,7 @@ jobs:
           - clang++-12
         build_type: [Debug, Release]
 
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
 
     env:
       CXX: ${{ matrix.compiler }}
@@ -84,7 +84,7 @@ jobs:
           - clang++-9
         build_type: [Debug, Release]
 
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
 
     env:
       CXX: ${{ matrix.compiler }}
@@ -137,7 +137,7 @@ jobs:
         flags: ["-fno-rtti", "-fms-extensions"]
         build_type: [Debug, Release]
 
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
 
     env:
       CXX: clang++

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -15,7 +15,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        xcode: ['11', '12', '13']
+        xcode: ['13', '14']
         build_type: [Debug, Release]
 
     runs-on: macos-latest

--- a/.github/workflows/no-filesystem.yml
+++ b/.github/workflows/no-filesystem.yml
@@ -15,7 +15,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        compiler: [g++, clang++]
+        compiler: [g++]
         build_type: [Release]
 
     runs-on: ubuntu-latest

--- a/.github/workflows/no-filesystem.yml
+++ b/.github/workflows/no-filesystem.yml
@@ -1,0 +1,38 @@
+name: No-Filesystem
+
+on:
+  push:
+    paths-ignore:
+      - 'README.md'
+      - 'doc/**'
+  pull_request:
+    paths-ignore:
+      - 'README.md'
+      - 'doc/**'
+
+jobs:
+  no-exceptions:
+    strategy:
+      fail-fast: false
+      matrix:
+        compiler: [g++, clang++]
+        build_type: [Release]
+
+    runs-on: ubuntu-latest
+
+    env:
+      CXX: ${{ matrix.compiler }}
+
+    steps:
+    - uses: actions/checkout@v2
+
+    - run: cmake -E make_directory build
+
+    - working-directory: build/
+      run: cmake $GITHUB_WORKSPACE -DCMAKE_BUILD_TYPE=${{ matrix.build_type }} -DPEGTL_USE_FILESYSTEM=OFF -DPEGTL_USE_BOOST_FILESYSTEM=OFF
+
+    - working-directory: build/
+      run: cmake --build .
+
+    - working-directory: build/
+      run: ctest --output-on-failure

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -50,6 +50,7 @@ target_include_directories(pegtl INTERFACE
 target_compile_features(pegtl INTERFACE cxx_std_17)
 
 option(PEGTL_USE_BOOST_FILESYSTEM "Override the auto-detection of std::filesystem and use Boost.Filesystem" OFF)
+option(PEGTL_USE_FILESYSTEM "Use available implementation of std::filesystem (std::, std::experiemntal, or Boost)" ON)
 
 # Try compiling a test program with std::filesystem or one of its alternatives
 function(check_filesystem_impl FILESYSTEM_HEADER FILESYSTEM_NAMESPACE OPTIONAL_LIBS OUT_RESULT)
@@ -82,7 +83,10 @@ function(check_filesystem_impl FILESYSTEM_HEADER FILESYSTEM_NAMESPACE OPTIONAL_L
   set(${OUT_RESULT} ${TEST_RESULT} PARENT_SCOPE)
 endfunction()
 
-if(PEGTL_USE_BOOST_FILESYSTEM)
+if (NOT PEGTL_USE_FILESYSTEM)
+  target_compile_definitions(${PROJECT_NAME} INTERFACE TAO_PEGTL_NO_FILESYSTEM)
+  message(STATUS "Skipping std::filesystem (or variant) in PEGTL; File operations will not work or compile.")
+elseif (PEGTL_USE_BOOST_FILESYSTEM)
   # Force the use of Boost.Filesystem: #include <boost/filesystem.hpp> // boost::filesystem
   find_package(Boost REQUIRED COMPONENTS filesystem)
   target_link_libraries(${PROJECT_NAME} INTERFACE Boost::filesystem)


### PR DESCRIPTION
I merged the PR #350 to a new branch created from 3.x, and added a new new validation in Actions to check that we don't break tests when running without filesystem.

The filesystem has a specific test `test_filesystem.cpp.in` that should be activated only when `PEGTL_USE_FILESYSTEM` is active. So this new regression test checks in case we break something when changing filesystem.


Related to #350 