### PR TITLE
add EOL option for cr_crlf_lf

### DIFF
--- a/include/tao/pegtl/eol.hpp
+++ b/include/tao/pegtl/eol.hpp
@@ -9,6 +9,7 @@
 
 #include "internal/eol.hpp"
 
+#include "internal/cr_crlf_lf_eol.hpp"
 #include "internal/cr_crlf_eol.hpp"
 #include "internal/cr_eol.hpp"
 #include "internal/crlf_eol.hpp"
@@ -28,6 +29,7 @@ namespace TAO_PEGTL_NAMESPACE
          // clang-format off
          struct cr : internal::cr_eol {};
          struct cr_crlf : internal::cr_crlf_eol {};
+         struct cr_crlf_lf : internal::cr_crlf_lf_eol {};
          struct crlf : internal::crlf_eol {};
          struct lf : internal::lf_eol {};
          struct lf_crlf : internal::lf_crlf_eol {};

--- a/include/tao/pegtl/internal/cr_crlf_lf_eol.hpp
+++ b/include/tao/pegtl/internal/cr_crlf_lf_eol.hpp
@@ -1,0 +1,48 @@
+// Copyright (c) 2016-2023 Dr. Colin Hirsch and Daniel Frey
+// Distributed under the Boost Software License, Version 1.0.
+// (See accompanying file LICENSE_1_0.txt or copy at https://www.boost.org/LICENSE_1_0.txt)
+
+#ifndef TAO_PEGTL_INTERNAL_CR_CRLF_LF_EOL_HPP
+#define TAO_PEGTL_INTERNAL_CR_CRLF_LF_EOL_HPP
+
+#include "data_and_size.hpp"
+
+#include "../config.hpp"
+
+namespace TAO_PEGTL_NAMESPACE::internal
+{
+   struct cr_crlf_lf_eol
+   {
+      static constexpr int ch = '\r';
+
+      template< typename ParseInput >
+      [[nodiscard]] static bool_and_size eol_match( ParseInput& in ) noexcept( noexcept( in.size( 2 ) ) )
+      {
+         bool_and_size p = { false, in.size( 2 ) };
+         if( p.size > 0 ) {
+            const auto a = in.peek_char();
+            if( a == '\n' ) {
+               in.bump_to_next_line();
+               p.size = 1;
+               p.data = true;
+            }
+            else if( a == '\r' ) {
+               if( ( p.size > 1 ) && ( in.peek_char( 1 ) == '\n' ) ) {
+                  in.bump_to_next_line( 2 );
+                  p.size = 2;
+                  p.data = true;
+               }
+               else {
+                  in.bump_to_next_line();
+                  p.size = 1;
+                  p.data = true;
+               }
+            }
+
+            return p;
+      }
+   };
+
+}  // namespace TAO_PEGTL_NAMESPACE::internal
+
+#endif

--- a/include/tao/pegtl/internal/cr_crlf_lf_eol.hpp
+++ b/include/tao/pegtl/internal/cr_crlf_lf_eol.hpp
@@ -38,8 +38,8 @@ namespace TAO_PEGTL_NAMESPACE::internal
                   p.data = true;
                }
             }
-
-            return p;
+         }
+         return p;
       }
    };
 

--- a/src/test/pegtl/ascii_eol.cpp
+++ b/src/test/pegtl/ascii_eol.cpp
@@ -82,6 +82,19 @@ namespace TAO_PEGTL_NAMESPACE
       verify_rule< eol, eol::cr_crlf >( __LINE__, __FILE__, "\r\na", result_type::success, 1 );
       verify_rule< eol, eol::cr_crlf >( __LINE__, __FILE__, "\r\n\r", result_type::success, 1 );
       verify_rule< eol, eol::cr_crlf >( __LINE__, __FILE__, "\r\n\n", result_type::success, 1 );
+
+      verify_rule< eol, eol::cr_crlf_lf >( __LINE__, __FILE__, " ", result_type::local_failure, 1 );
+      verify_rule< eol, eol::cr_crlf_lf >( __LINE__, __FILE__, "\r", result_type::success, 0 );
+      verify_rule< eol, eol::cr_crlf_lf >( __LINE__, __FILE__, "\n", result_type::success, 0 );
+      verify_rule< eol, eol::cr_crlf_lf >( __LINE__, __FILE__, "\r\n", result_type::success, 0 );
+      verify_rule< eol, eol::cr_crlf_lf >( __LINE__, __FILE__, "\n\r", result_type::success, 1 );
+      verify_rule< eol, eol::cr_crlf_lf >( __LINE__, __FILE__, "\n\r\n", result_type::success, 2 );
+      verify_rule< eol, eol::cr_crlf_lf >( __LINE__, __FILE__, "\n\r\r", result_type::success, 2 );
+      verify_rule< eol, eol::cr_crlf_lf >( __LINE__, __FILE__, "\na", result_type::success, 1 );
+      verify_rule< eol, eol::cr_crlf_lf >( __LINE__, __FILE__, "\ra", result_type::success, 1 );
+      verify_rule< eol, eol::cr_crlf_lf >( __LINE__, __FILE__, "\r\na", result_type::success, 1 );
+      verify_rule< eol, eol::cr_crlf_lf >( __LINE__, __FILE__, "\r\n\r", result_type::success, 1 );
+      verify_rule< eol, eol::cr_crlf_lf >( __LINE__, __FILE__, "\r\n\n", result_type::success, 1 );
    }
 
 }  // namespace TAO_PEGTL_NAMESPACE


### PR DESCRIPTION
I'm currently writing a parser where the grammar specifies a line termination as `(\r\n?)|\n`. This (I don't think) is currently an option for a valid line ending in PEGTL.

I wrote the following code as an attempt to rectify this. I think I added everything that I needed to, but there is a high chance I didn't.

I added to the tests in [ascii_eol.cpp](https://github.com/taocpp/PEGTL/blob/main/src/test/pegtl/ascii_eol.cpp). I'm assuming that the final argument in `verify_rule` is the number of characters remaining in the input string after a single sucessful match of the rule to the beginning of the string.

Is this something you're interested in?