### PR TITLE
[infrastructure] Update Codecov upload steps

### DIFF
--- a/.github/workflows/code-coverage.yml
+++ b/.github/workflows/code-coverage.yml
@@ -28,5 +28,7 @@ jobs:
     - working-directory: build/
       run: ctest --output-on-failure
 
-    - working-directory: build/
-      run: bash <(curl -s https://codecov.io/bash)
+    - name: Upload coverage reports to Codecov with GitHub Action
+      uses: codecov/codecov-action@v4.2.0
+      with:
+        token: ${{ secrets.CODECOV_TOKEN }}


### PR DESCRIPTION
The current Codecov is not receiving the Code coverage results anymore, the last report is 3 months old: https://app.codecov.io/gh/taocpp/PEGTL/tree/work

The Codecov changed a bit, now they have an integrated Github Action, that can be connected directly to project: https://github.com/marketplace/actions/codecov

The current upload steps are a bit different, not including the new integrated application, but the token used for upload: https://docs.codecov.com/docs/github-2-getting-a-codecov-account-and-uploading-coverage#install-the-github-app-integration