### PR TITLE
[infra] Simplify clang-tidy usage

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -35,6 +35,7 @@ Checks: >-
   -readability-identifier-length,
   -readability-magic-numbers,
   -readability-static-accessed-through-instance,
+  -llvm-header-guard,
 
 CheckOptions:
   - { key: readability-identifier-naming.ClassCase,     value: lower_case }

--- a/.github/workflows/clang-tidy.yml
+++ b/.github/workflows/clang-tidy.yml
@@ -15,12 +15,18 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
 
-    - run: sudo apt-get update -yq
+    - name: Install Dependencies
+      run: |
+        sudo apt-get -qq update -yq
+        sudo apt-get -qq install -y clang-tidy --no-install-recommends --no-install-suggests
 
-    - run: sudo apt-get install -yq clang-tidy
+    - name: Generate Compilation Database
+      run: cmake -S . -B build -DCMAKE_EXPORT_COMPILE_COMMANDS=ON
 
-    - run: find include/ -name '*.hpp' | grep -vF mmap_file_win32.hpp | grep -vF endian_win.hpp | xargs -I '{}' clang-tidy --quiet '{}' -- --std=c++17 -Iinclude
+    - name: Run clang-tidy on Header Files
+      run: find include/ -type f \( -name "*.hpp" -a ! -name "endian_win.hpp" -a ! -name "mmap_file_win32.hpp" \) -exec clang-tidy {} -quiet -p=build -- -std=c++17 -I include \;
 
-    - run: find src/ -name '*.cpp' | xargs -I '{}' clang-tidy --quiet '{}' -- --std=c++17 -Iinclude
+    - name: Run clang-tidy on Source Files
+      run: find include/ -type f -name "*.cpp" -exec clang-tidy {} -quiet -p=build -- -std=c++17 -I include \;

--- a/.github/workflows/clang-tidy.yml
+++ b/.github/workflows/clang-tidy.yml
@@ -26,4 +26,8 @@ jobs:
       run: cmake -S . -B build -DCMAKE_EXPORT_COMPILE_COMMANDS=ON
 
     - name: Run clang-tidy on Header Files
-      run: frun-clang-tidy -p build -j $(nproc) -quiet -header-filter='.*' -extra-arg=-std=c++17 -extra-arg=-Iinclude
+      run: find include/ -type f \( -name "*.hpp" -a ! -name "endian_win.hpp" -a ! -name "mmap_file_win32.hpp" \) | xargs -P $(nproc) -I {} clang-tidy -quiet -p build {} -- -std=c++17 -Iinclude
+
+    - name: Run clang-tidy on tests and examples files
+      continue-on-error: true
+      run: find src/ -type f -name "*.cpp" | xargs -P $(nproc) -I {} clang-tidy -quiet -p build {} -- -std=c++17 -Iinclude

--- a/.github/workflows/clang-tidy.yml
+++ b/.github/workflows/clang-tidy.yml
@@ -26,7 +26,4 @@ jobs:
       run: cmake -S . -B build -DCMAKE_EXPORT_COMPILE_COMMANDS=ON
 
     - name: Run clang-tidy on Header Files
-      run: find include/ -type f \( -name "*.hpp" -a ! -name "endian_win.hpp" -a ! -name "mmap_file_win32.hpp" \) -exec clang-tidy {} -quiet -p=build -- -std=c++17 -I include \;
-
-    - name: Run clang-tidy on Source Files
-      run: find include/ -type f -name "*.cpp" -exec clang-tidy {} -quiet -p=build -- -std=c++17 -I include \;
+      run: frun-clang-tidy -p build -j $(nproc) -quiet -header-filter='.*' -extra-arg=-std=c++17 -extra-arg=-Iinclude

--- a/.github/workflows/clang-tidy.yml
+++ b/.github/workflows/clang-tidy.yml
@@ -26,6 +26,7 @@ jobs:
       run: cmake -S . -B build -DCMAKE_EXPORT_COMPILE_COMMANDS=ON
 
     - name: Run clang-tidy on Header Files
+      continue-on-error: true
       run: find include/ -type f \( -name "*.hpp" -a ! -name "endian_win.hpp" -a ! -name "mmap_file_win32.hpp" \) | xargs -P $(nproc) -I {} clang-tidy -quiet -p build {} -- -std=c++17 -Iinclude
 
     - name: Run clang-tidy on tests and examples files

--- a/include/tao/pegtl/internal/read_file_stdio.hpp
+++ b/include/tao/pegtl/internal/read_file_stdio.hpp
@@ -124,7 +124,7 @@ namespace TAO_PEGTL_NAMESPACE::internal
       {
          std::string nrv;
          if( const std::size_t s = size(); s > 0 ) {
-            TAO_PEGTL_NAMESPACE::internal::resize_uninitialized( nrv, s ); // NOLINT(clang-diagnostic-error)
+            resize_uninitialized( nrv, s );
             read_impl( nrv.data(), nrv.size() );
          }
          return nrv;

--- a/include/tao/pegtl/internal/read_file_stdio.hpp
+++ b/include/tao/pegtl/internal/read_file_stdio.hpp
@@ -124,7 +124,7 @@ namespace TAO_PEGTL_NAMESPACE::internal
       {
          std::string nrv;
          if( const std::size_t s = size(); s > 0 ) {
-            resize_uninitialized( nrv, s );
+            TAO_PEGTL_NAMESPACE::internal::resize_uninitialized( nrv, s ); // NOLINT(clang-diagnostic-error)
             read_impl( nrv.data(), nrv.size() );
          }
          return nrv;


### PR DESCRIPTION
This PR "improves" the current usage of Clang tidy in the CI:

- First, it runs Cmake to obtain exported commands, which can be analyzed by clang-tidy
- Similar to the first, clang-tidy is now running in parallel with xargs -P
- Only errors from project headers are considered critical for failure
- When failing it will mark as failed, but will not break the CI. Which means it is optional, not a blocker

@ColinH @d-frey We could have it as technical debt, what do you think? 
