### PR TITLE
Limit `__PRETTY_FUNCTION__` workaround to GCC 16.1.x rather than all of GCC 16.x.x

### DIFF
--- a/include/tao/pegtl/internal/demangle_gcc.hpp
+++ b/include/tao/pegtl/internal/demangle_gcc.hpp
@@ -5,7 +5,7 @@
 #ifndef TAO_PEGTL_INTERNAL_DEMANGLE_CLANG_HPP
 #define TAO_PEGTL_INTERNAL_DEMANGLE_CLANG_HPP
 
-#if ( ( __GNUC__ == 9 ) && ( __GNUC_MINOR__ < 3 ) ) || ( __GNUC__ == 16 )
+#if ( ( __GNUC__ == 9 ) && ( __GNUC_MINOR__ < 3 ) ) || ( ( __GNUC__ == 16 ) && ( __GNUC_MINOR__ < 2 ) )
 
 // GCC 9.1 and 9.2 can truncate __PRETTY_FUNCTION__.
 // The bug was fixed in 9.3 but is back again in 16.1.

--- a/src/test/demangle.cpp
+++ b/src/test/demangle.cpp
@@ -35,7 +35,7 @@ namespace TAO_PEGTL_NAMESPACE
    void unit_test()
    {
       const std::string ns = TAO_PEGTL_STRINGIFY( TAO_PEGTL_NAMESPACE );
-#if !defined( __clang__ ) && defined( __GNUC__ ) && ( ( ( __GNUC__ == 9 ) && ( __GNUC_MINOR__ <= 2 ) ) || ( __GNUC__ == 16 ) )
+#if !defined( __clang__ ) && defined( __GNUC__ ) && ( ( ( __GNUC__ == 9 ) && ( __GNUC_MINOR__ <= 2 ) ) || ( ( __GNUC__ == 16 ) && ( __GNUC_MINOR__ <= 1 ) ) )
       // See https://gcc.gnu.org/bugzilla/show_bug.cgi?id=91155
 #if defined( __cpp_rtti )
       test_typeid< int >();


### PR DESCRIPTION
Fixes #384

Follow-up on commit 0176e87da3a02d0ab40ce39f03e0e4108d1bbba5.

Related GCC upstream issue:
https://gcc.gnu.org/bugzilla/show_bug.cgi?id=91155#c20

Related issues:
- https://github.com/taocpp/PEGTL/issues/384
- https://github.com/taocpp/PEGTL/issues/382