### PR TITLE
[main] `doc/Install-Guide.md`: Document GCC 16.1 (rather than 16.x) issues

### DIFF
--- a/doc/Install-Guide.md
+++ b/doc/Install-Guide.md
@@ -94,7 +94,7 @@ Some tests and examples are (partially) disabled when compiling without exceptio
 ## Disabling RTTI
 
 The PEGTL is compatible with `-fno-rtti` on GCC, Clang, and MSVC.
-The only exceptions are GCC versions 9.1, 9.2 and 16 due to an unfortunate compiler bug, see [bug #91155](https://gcc.gnu.org/bugzilla/show_bug.cgi?id=91155).
+The only exceptions are GCC versions 9.1, 9.2 and 16.1 due to an unfortunate compiler bug, see [bug #91155](https://gcc.gnu.org/bugzilla/show_bug.cgi?id=91155).
 
 On other compilers [RTTI](https://en.wikipedia.org/wiki/Run-time_type_information) is required by default (for demangling, see `include/tao/pegtl/demangle.hpp`).
 Let us know if you use such a compiler since an RTTI-free compiler-specific demangling function might be possible.


### PR DESCRIPTION
For #386 

CC @ColinH 